### PR TITLE
Fix missing 'org.' in icon theme field name

### DIFF
--- a/settings/com.endlessm.gschema.override
+++ b/settings/com.endlessm.gschema.override
@@ -20,7 +20,7 @@ gtk-theme='EndlessOS'
 theme='EndlessOS'
 
 # Select the icon theme
-[gnome.desktop.interface]
+[org.gnome.desktop.interface]
 icon-theme='EndlessOS'
 
 # Select the cursor theme


### PR DESCRIPTION
[endlessm/eos-shell#132]
