### PR TITLE
Add separate CSS file for Endless SDK widgets

### DIFF
--- a/themes/EndlessOS/gtk-3.0/Makefile.am
+++ b/themes/EndlessOS/gtk-3.0/Makefile.am
@@ -15,6 +15,7 @@ theme_DATA = 		\
 	gtk.gresource	\
 	gtk.css 	\
 	gtk-dark.css	\
+	endless-widgets.css \
 	settings.ini
 
 resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/gtk.gresource.xml)
@@ -26,6 +27,7 @@ EXTRA_DIST = \
 	gtk.css \
 	gtk-dark.css \
 	gtk.gresource.xml \
+	endless-widgets.css \
 	settings.ini
 
 CLEANFILES = \

--- a/themes/EndlessOS/gtk-3.0/endless-widgets.css
+++ b/themes/EndlessOS/gtk-3.0/endless-widgets.css
@@ -1,0 +1,27 @@
+/* Endless window top bar */
+
+.top-bar {
+    background-image: -gtk-gradient(linear, center top, center bottom,
+        from(#343434), to(#262624));
+}
+
+.top-bar .button {
+    color: #8a8a8a;
+    icon-shadow: 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.top-bar .button:hover {
+    color: #ffffff;
+    icon-shadow: 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.top-bar .button:active
+/* .button *:active Needed to override Adwaita */ {
+    color: #464646;
+    icon-shadow: none;
+    /* TODO: In proper CSS the above line is done as follows:
+    position: relative;
+    top: 1px;
+    Replace the style property below when they are supported in GTK. */
+    -GtkButton-child-displacement-y: 1px;
+}

--- a/themes/EndlessOS/gtk-3.0/gtk.css
+++ b/themes/EndlessOS/gtk-3.0/gtk.css
@@ -1,1 +1,4 @@
 @import url("resource:///org/gnome/adwaita/gtk-main.css");
+
+/* Endless widget-specific theme */
+@import url("endless-widgets.css");


### PR DESCRIPTION
This CSS file should contain CSS that is specific to widgets from
our SDK.
[endlessm/eos-sdk#20]
