### PR TITLE
Add endless-widgets.css to resource file

### DIFF
--- a/themes/EndlessOS/gtk-3.0/Makefile.am
+++ b/themes/EndlessOS/gtk-3.0/Makefile.am
@@ -15,7 +15,6 @@ theme_DATA = 		\
 	gtk.gresource	\
 	gtk.css 	\
 	gtk-dark.css	\
-	endless-widgets.css \
 	settings.ini
 
 resource_files = $(shell $(GLIB_COMPILE_RESOURCES) --sourcedir=$(srcdir) --generate-dependencies $(srcdir)/gtk.gresource.xml)
@@ -27,7 +26,6 @@ EXTRA_DIST = \
 	gtk.css \
 	gtk-dark.css \
 	gtk.gresource.xml \
-	endless-widgets.css \
 	settings.ini
 
 CLEANFILES = \

--- a/themes/EndlessOS/gtk-3.0/gtk.css
+++ b/themes/EndlessOS/gtk-3.0/gtk.css
@@ -1,4 +1,4 @@
 @import url("resource:///org/gnome/endlessos/gtk-main.css");
 
 /* Endless widget-specific theme */
-@import url("endless-widgets.css");
+@import url("resource:///org/gnome/endlessos/endless-widgets.css");

--- a/themes/EndlessOS/gtk-3.0/gtk.gresource.xml
+++ b/themes/EndlessOS/gtk-3.0/gtk.gresource.xml
@@ -223,5 +223,6 @@
     <file>gtk-main-common.css</file>
     <file>gtk-main-dark.css</file>
     <file>gtk-fallback.css</file>
+    <file>endless-widgets.css</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
Use the resource file instead of adding it directly to gtk.css.

[endlessm/eos-sdk#216]
