### PR TITLE
Add asset for edit-find-symbolic icon

### DIFF
--- a/icons/scalable/actions/edit-find-symbolic.svg
+++ b/icons/scalable/actions/edit-find-symbolic.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Google_x2B_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="16px" height="16px" viewBox="42.5 58.5 16 16" enable-background="new 42.5 58.5 16 16" xml:space="preserve">
+<path d="M58.208,72.087l-3.681-3.68C55.141,67.416,55.5,66.251,55.5,65c0-3.59-2.91-6.5-6.5-6.5s-6.5,2.91-6.5,6.5s2.91,6.5,6.5,6.5
+	c1.251,0,2.415-0.359,3.407-0.972l3.68,3.68c0.389,0.389,1.025,0.389,1.414,0l0.707-0.707
+	C58.597,73.112,58.597,72.476,58.208,72.087z M44.25,65c0-2.623,2.127-4.75,4.75-4.75s4.75,2.127,4.75,4.75s-2.127,4.75-4.75,4.75
+	S44.25,67.623,44.25,65z"/>
+</svg>


### PR DESCRIPTION
This replaces the stock edit-find-symbolic icon from the gnome set with the one made by @rpitanga, and is used in every search entry.

[endlessm/eos-shell#86]
