### PR TITLE
Make epiphany open exploration-center website automatically when launched

### DIFF
--- a/desktop/applications.csv
+++ b/desktop/applications.csv
@@ -37,4 +37,4 @@ video,,,,,X,X,X,X,Videos,,Vídeos,Vídeos,,Video,,,,,totem %U,,,,,video,,,,,Vide
 weather,,,,,X,X,X,X,Weather,,Tiempo,Tempo,,See the weather forecast,,,,,endless-os-weather,,,,,weather,,,,,Network;News;
 writer,,,,,X,X,X,X,Writer,,Escritor,Redator,,Writer,,,,,libreoffice --writer %U,,,,,office_text,,,,,Office;
 youtube,,,,,X,X,X,X,YouTube,,YouTube,YouTube,,YouTube,,,,,endless-os-youtube,,,,,youtube-app,,,,,Media;
-epiphany,,,,,X,X,X,X,Internet,,,,,Browse the Web,,,,,epiphany,,,,,emblem-web,,,,,Internet;
+epiphany,,,,,X,X,X,X,Internet,,,,,Browse the Web,,,,,epiphany file:///usr/share/EndlessOS/exploration_center/index.html,,,,,emblem-web,,,,,Internet;


### PR DESCRIPTION
This adds exploration-center url as argument to epiphany's execute command in
its .desktop file.

[endlessm/eos-shell#221]

This issue depends on [endlessm/eos-exploration-center#105] to be fixed, but perhaps it can already be reviewed and even merged.
