### PR TITLE
Disable reporting of Ubuntu internal errors via apport

### DIFF
--- a/settings/com.endlessm.gschema.override.in
+++ b/settings/com.endlessm.gschema.override.in
@@ -63,3 +63,6 @@ icon-grid-layout={ '': ['eos-app-epiphany.desktop', 'eos-link-facebook.desktop',
 [org.gnome.nautilus.preferences]
 default-folder-viewer='list-view'
 
+# Disable reporting of Ubuntu internal error messages
+[com.ubuntu.update-notifier]
+show-apport-crashes=false


### PR DESCRIPTION
[endlessm/eos-shell#212]
