### PR TITLE
Autostart eos-app-epiphany

### DIFF
--- a/desktop/Makefile.am
+++ b/desktop/Makefile.am
@@ -34,6 +34,9 @@ links_DATA = $(wildcard links/*.desktop)
 foldersdir = $(datadir)/desktop-directories
 folders_DATA = $(wildcard folders/*.directory)
 
+autostartdir = $(sysconfdir)/xdg/autostart
+autostart_DATA = applications/eos-app-epiphany.desktop
+
 clean-local:
 	rm -rf applications
 	rm .apps_dot_desktop_files_timestamp


### PR DESCRIPTION
Install the desktop file in autostart place, so it is started everytime we log in the desktop

[endlessm/eos-shell#242]
