### PR TITLE
Do not restore Epiphany closed tabs

### DIFF
--- a/settings/com.endlessm.gschema.override.in
+++ b/settings/com.endlessm.gschema.override.in
@@ -66,3 +66,7 @@ default-folder-viewer='list-view'
 # Disable reporting of Ubuntu internal error messages
 [com.ubuntu.update-notifier]
 show-apport-crashes=false
+
+# Do not restore Epiphany previous session (unless crashed)
+[org.gnome.Epiphany]
+restore-session-policy='crashed'


### PR DESCRIPTION
Do not restore previous closed tabs in Epiphany, unless a crash
happened.

[endlessm/eos-shell#467]
