### PR TITLE
Decrease the likelihood that an unsteady click is interpreted as a drag

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -69,3 +69,7 @@ show-apport-crashes=false
 [org.gnome.Epiphany]
 restore-session-policy='never'
 
+# Decrease the likelihood that an unsteady click is interpreted as a drag
+[org.gnome.settings-daemon.peripherals.mouse]
+drag-threshold=10
+


### PR DESCRIPTION
Increases the drag threshold from the default of 8 pixels to 10 pixels.

[endlessm/eos-shell#517]
