### PR TITLE
Set gsetting to not let Nautilus manage the desktop

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -73,3 +73,7 @@ restore-session-policy='never'
 [org.gnome.settings-daemon.peripherals.mouse]
 drag-threshold=10
 
+# Do not let Nautilus manage the desktop
+[org.gnome.desktop.background]
+show-desktop-icons=false
+


### PR DESCRIPTION
This fixes the display of the desktop app selector icons after minimizing the social bar.

[endlessm/eos-shell#568]
