### PR TITLE
Start GCompris in window mode.

### DIFF
--- a/desktop/applications.csv
+++ b/desktop/applications.csv
@@ -10,7 +10,7 @@ evolution,work:10,work:10,work:10,X,X,X,E-mail,,,,,E-mail,,,,,evolution %U,,,,,e
 frostwire,media:40,media:40,media:40,X,X,X,Media Download,,Descargar,Baixar Mídia,,FrostWire,,,,,frostwire,,,,,frostwire,,,,,Network;
 gbrainy,,,,X,X,X,Brain Teasers,,Rompecabezas,Quebra-cabeça,,GBrainy,,,,,gbrainy,,,,,gbrainy,,,,,Games;
 gcalctool,work:50,work:50,work:50,X,X,X,Calculator,,Calculadora,Calculadora,,Calculator,,,,,gnome-calculator,,,,,calculator,,,,,Utility;Calculator;
-gcompris,curiosity:70,curiosity:70,curiosity:70,X,X,X,GCompris,,,,,Childrens games,,,,,gcompris,,,,,gcompris,,,,,Games;Education;
+gcompris,curiosity:70,curiosity:70,curiosity:70,X,X,X,GCompris,,,,,Childrens games,,,,,gcompris -w,,,,,gcompris,,,,,Games;Education;
 gimp,media:50,media:50,media:50,X,X,X,GIMP,,,,,Photo Editor,,Editor de Imágenes,Editor de Imagens,图像编辑器,gimp %U,,,,,gimp,,,,,Photos;
 gnome-genius,,,,X,X,X,Math,,Matemáticas,Matemática,,Genius Math,,,,,gnome-genius,,,,,geniusmath,,,,,Utility;Calculator;
 gnome-sudoku,,,,X,X,X,Sudoku,,,,,Sudoku,,,,,/usr/games/gnome-sudoku,,,,,sudoku,,,,,Games;


### PR DESCRIPTION
This adds the title bar with minimize/close buttons.  Although the user could change to fullscreen mode within the application settings, it will revert to window mode whenever it is launched.

[endlessm/eos-shell#497]
