### PR TITLE
Fix launch of English and translate apps

### DIFF
--- a/desktop/applications.csv
+++ b/desktop/applications.csv
@@ -4,7 +4,7 @@ audacity,,,,X,X,X,Audio Editor,,Señor DJ,Edita Som,,Audacity,,,,,audacity,,,,,a
 billard-gl,,,,X,X,X,Billiards,,Billar,Sinuca,,BillardGL,,,,,billard-gl,,,,,billardgl,,,,,Games;
 blockout2,,,,X,X,X,BlockOut 2,,BlockOut 2,BlockOut 2,,3D Tetris-style game,,,,,blockout2,,,,,blockout2,,,,,Games;
 chromium-bsu,games:60,games:60,games:60,X,X,X,Chromium BSU,,,,,Chromium BSU,,,,,chromium-bsu --fullscreen,,,,,chromium-bsu,,,,,Games;
-english,curiosity:30,curiosity:30,curiosity:30,X,X,X,Learn English,,Aprende Inglés,Aprender Inglês,,Learn English,,,,,gjs /usr/share/eos-english/english_app.js,,,,,english-app,,,,,Education;
+english,curiosity:30,curiosity:30,curiosity:30,X,X,X,Learn English,,Aprende Inglés,Aprender Inglês,,Learn English,,,,,gjs /usr/share/eos-english/src/english_app.js,,,,,english-app,,,,,Education;
 epiphany,10,10,10,X,X,X,Internet,,,,,Browse the Web,,,,,epiphany file:///usr/share/EndlessOS/exploration_center/index.html,,,,,browser,,,,,Internet;
 evolution,work:10,work:10,work:10,X,X,X,E-mail,,,,,E-mail,,,,,evolution %U,,,,,email,,,,,Mail;Email;
 frostwire,media:40,media:40,media:40,X,X,X,Media Download,,Descargar,Baixar Mídia,,FrostWire,,,,,frostwire,,,,,frostwire,,,,,Network;


### PR DESCRIPTION
Temporary solution that adapts to the new source directory structure.
In the long run, these apps should provide a wrapper script in /usr/bin.
May be revisited once the new app launcher is implemented.

[endlessm/eos-shell#606]
