### PR TITLE
Change browser setting to never restore session

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -65,8 +65,8 @@ default-folder-viewer='list-view'
 [com.ubuntu.update-notifier]
 show-apport-crashes=false
 
-# Do not restore Epiphany previous session
-[org.gnome.Epiphany]
+# Do not restore browser previous session
+[org.gnome.eos-browser]
 restore-session-policy='never'
 
 # Decrease the likelihood that an unsteady click is interpreted as a drag


### PR DESCRIPTION
After exiting the browser, the next time we launch the browser we want
to always open a single tab with the exploration center rather than all
the previous tabs the user had opened.

[endlessm/eos-shell#682]
