### PR TITLE
Revert to full version of grooveshark

### DIFF
--- a/desktop/links.csv
+++ b/desktop/links.csv
@@ -36,7 +36,7 @@ gnt,,,,,X,,GNT,,,,,,,,,,http://gnt.globo.com,,,,,gnt,,,,,Entertainment;Games;
 google,,,,X,X,X,Google,,,,,,,,,,http://www.google.com,,,,,google,,,,,Network;
 googlebooks,media:70,media:70,media:70,X,X,X,Books,,Libros,Livros,书籍,,,,,,http://books.google.com,,http://books.google.com.gt/books?hl=es,http://books.google.com.br/books?hl=pt-BR,http://books.google.com.br/books?hl=zh_CN,google-books,,,,,Network;
 gritodanacao,,,,,X,,Grito da Nacao,,,,,,,(614) 886-6032,,,http://blogs.lancenet.com.br/gritodanacao,,,,,grito-da-nacao,,,,,Sports;
-grooveshark,60,60,60,X,X,X,Online Music,,Música Virtual,Música Online,在线音乐,Grooveshark,,,,,http://html5.grooveshark.com,,,,,grooveshark,,,,,Entertainment;Games;
+grooveshark,60,60,60,X,X,X,Online Music,,Música Virtual,Música Online,在线音乐,Grooveshark,,,,,http://grooveshark.com,,,,,grooveshark,,,,,Entertainment;Games;
 guatemala,,,news:30,,,X,Gobierno de Guatemala,,,,,,,,,,http://www.guatemala.gob.gt,,,,,guatemala,,,,,Network;
 guiadasemana,,,,,X,,Guia da Semana,,,,,,,,,,http://www.guiadasemana.com/br/rio-de-janeiro,,,,,guia-da-semana,,,,,Rio;
 imdb,,,,X,X,X,IMDb,,,,,,,,,,http://www.imdb.com,,,,,imdb,,,,,Entertainment;Games;


### PR DESCRIPTION
We support Flash on Intel, so for now we should use the default URL
that is more robust and uses Flash instaed of HTML5.

[endlessm/eos-shell#742]
