### PR TITLE
Fix semicolons in desktop entry Categories

### DIFF
--- a/desktop/applications.csv
+++ b/desktop/applications.csv
@@ -1,46 +1,46 @@
-Id,Desktop,Desktop[Brazil],Desktop[Guatemala],AppStore,AppStore[Brazil],AppStore[Guatemala],Name,Name[en],Name[es],Name[pt],Name[zh],Comment,Comment[en],Comment[es],Comment[pt],Comment[zh],TryExec,Exec,Exec[en],Exec[es],Exec[pt],Exec[zh],Icon,Icon[en],Icon[es],Icon[pt],Icon[zh],Categories,,,
-armagetron,,,,X,X,X,Armagetron,,Armagetron,Armagetron,,3d light cycle game,,,,,,armagetronad,,,,,armagetron-adv,,,,,Games,,,
-audacity,,,,X,X,X,Audio Editor,,Señor DJ,Edita Som,,Audacity,,,,,,audacity,,,,,audacity,,,,,Audio,,,
-billard-gl,,,,X,X,X,Billiards,,Billar,Sinuca,,BillardGL,,,,,,billard-gl,,,,,billardgl,,,,,Games,,,
-blockout2,,,,X,X,X,BlockOut 2,,BlockOut 2,BlockOut 2,,3D Tetris-style game,,,,,,blockout2,,,,,blockout2,,,,,Games,,,
-brazil,curiosity:15,curiosity:15,,X,X,,Brazil,,,Brasil,,Explore Brasil,,,,,eos-brazil,gjs /usr/share/eos-brazil/src/endless_brazil.js,,,,,brazil,,,,,Education,Travel,,
-chromium-browser,10,10,10,X,X,X,Internet,,,,,Browse the Web,,,,,,chromium-browser %U,,,,,browser,,,,,Internet,,,
-chromium-bsu,games:60,games:60,games:60,X,X,X,Chromium BSU,,,,,Chromium BSU,,,,,chromium-bsu,resfix chromium-bsu --fullscreen,,,,,chromium-bsu,,,,,Games,,,
-english,curiosity:30,curiosity:30,curiosity:30,X,X,X,Learn English,,Aprende Inglés,Aprender Inglês,,Learn English,,,,,eos-english,gjs /usr/share/eos-english/src/english_app.js,,,,,english-app,,,,,Education,,,
-evolution,work:10,work:10,work:10,X,X,X,E-mail,,,,,E-mail,,,,,,evolution %U,,,,,email,,,,,Mail,Email,,
-frostwire,media:40,media:40,media:40,X,X,X,Media Download,,Descargar,Baixar Mídia,,FrostWire,,,,,,frostwire,,,,,frostwire,,,,,Network,,,
-gcalctool,work:50,work:50,work:50,X,X,X,Calculator,,Calculadora,Calculadora,,Calculator,,,,,,gnome-calculator,,,,,calculator,,,,,Utility,Calculator,,
-gcompris,curiosity:70,curiosity:70,curiosity:70,X,X,X,EduGames,,EduJuegos,Joginhos,教育游戏,GCompris childrens games,,,,,,gcompris,,,,,gcompris,,,,,Games,Education,,
-gimp,media:50,media:50,media:50,X,X,X,GIMP,,,,,Photo Editor,,Editor de Imágenes,Editor de Imagens,图像编辑器,,gimp %U,,,,,gimp,,,,,Photos,,,
-gnome-genius,,,,X,X,X,Math,,Matemáticas,Matemática,,Genius Math,,,,,,gnome-genius,,,,,geniusmath,,,,,Utility,Calculator,,
-gnome-sudoku,,,,X,X,X,Sudoku,,,,,Sudoku,,,,,,/usr/games/gnome-sudoku,,,,,sudoku,,,,,Games,,,
-goldendict,,,,X,X,X,Dictionary,,Dicionário,Dicionário,,GoldenDict,,,,,,goldendict,,,,,goldendict,,,,,Utility,,,
-health,curiosity:17,curiosity:17,,X,X,,Health,,Salud,Saúde,,Discover health,,,,,eos-health,gjs /usr/share/eos-health/src/endless_health.js,,,,,health,,,,,Education,,,
-khanacademy,curiosity:40,curiosity:40,curiosity:40,X,X,X,Khan Academy,,Academia Khan,Academia Khan,,Khan Academy,,,,,,eos-khanacademy,,,,,khanacademy-app,,,,,Education,,,
-kobodeluxe,,,,X,X,X,Kobo Deluxe,,Kobo Deluxe,Kobo Deluxe,,Destroy enemy bases in space,,,,,kobodl,resfix kobodl -fullscreen,,,,,kobodeluxe,,,,,Games,,,
-lbreakout2,,,,X,X,X,Breakout,,El Escape,Fuga,,LBreakout2 game,,,,,,lbreakout2,,,,,lbreakout,,,,,Games,,,
-libreoffice-calc,work:20,work:20,work:20,X,X,X,Spreadsheet,,Hoja de Cálculo,Planilha,,Spreadsheet,,,,,,libreoffice --calc %U,,,,,office_spreadsheet,,,,,Office,,,
-libreoffice-impress,work:30,work:30,work:30,X,X,X,Presentation,,Presentación,Apresentação,,Impress,,,,,,libreoffice --impress %U,,,,,office_presentation,,,,,Office,,,
-libreoffice-writer,50,50,50,X,X,X,Writer,,Escritor,Redator,,Writer,,,,,,libreoffice --writer %U,,,,,office_text,,,,,Office,,,
-nautilus,80,80,80,X,X,X,My Documents,,Documentos,Documentos,,File Manager,,,,,,nautilus,,,,,nautilus,,,,,FileManager,Utility,Core,GTK
-numptyphysics,,,,X,X,X,Physics,,Retos,Fisicando,,Numpty Physics game,,,,,,numptyphysics,,,,,fisicando,,,,,Games,Education,,
-openarena,games:10,games:10,games:10,X,X,X,Open Arena,,,,,Open Arena,,,,,/usr/games/openarena,resfix /usr/games/openarena,,,,,openarena,,,,,Games,,,
-photos,70,70,70,X,X,X,Photo Editor,,Editor de Fotos,Editor de Fotos,照片编辑器,Endless Photo App,,,,,,endless-os-photos %f,,,,,photo,,,,,Photos,,,
-pingus,,,,X,X,X,Pingus,,,,,Penguin Game,,,,,,pingus,,,,,pingus,,,,,Games,,,
-rhythmbox,media:30,media:30,media:30,X,X,X,Music,,Música,Música,,Music,,,,,,rhythmbox %U,,,,,music,,,,,Audio,,,
-shotwell,media:10,media:10,media:10,X,X,X,Photos,,Fotos,Fotos,,Shotwell Photo Organizer,,,,,,shotwell %U,,,,,shotwell,,,,,Photos,,,
-skype,40,40,40,X,X,X,Skype,,,,,Skype,,,,,,skype %U,,,,,skype,,,,,Network,,,
-sol,games:40,games:40,games:40,X,X,X,Freecell,,,,,Freecell,,,,,,/usr/games/sol --freecell,,,,,freecell,,,,,Games,,,
-solitaire,games:30,games:30,games:30,X,X,X,Solitaire,,,,,Solitaire,,,,,,/usr/games/sol --class=solitaire,,,,,solitaire,,,,,Games,,,
-stellarium,curiosity:80,curiosity:80,curiosity:80,X,X,X,Stellarium,,Constelaciones,Constelação,,Stellarium,,,,,,stellarium-wrapper,,,,,stellarium,,,,,Astronomy,Education,Science,
-supertux2,games:50,games:50,games:50,X,X,X,Super Tux,,,,,Super Tux,,,,,supertux2,resfix supertux2 --fullscreen,,,,,supertux,,,,,Games,,,
-supertuxkart,games:70,games:70,games:70,X,X,X,Tux Kart,,,,,Tux Kart,,,,,supertuxkart,resfix supertuxkart --fullscreen,,,,,supertuxkart,,,,,Games,,,
-teeworlds,,,,X,X,X,Teeworlds,,Teelandia,Teelândia,,Multiplayer game,,,,,teeworlds,resfix teeworlds,,,,,teelandia,,,,,Games,,,
-totem,media:20,media:20,media:20,X,X,X,Videos,,Vídeos,Vídeos,,Video,,,,,,totem %U,,,,,video,,,,,Video,,,
-translate,curiosity:20,curiosity:20,curiosity:20,X,X,X,Translate,,Traductor,Tradutor,翻译,Translate,,,,,,gjs /usr/share/eos-translation/translation_app.js,,,,,translate,,,,,Education,Office,,
-tuxmath,,,,X,X,X,Tux Math,,123 Tux,123 Tux,,Math Games,,,,,,tuxmath,,,,,123tux,,,,,Games,Education,,
-tuxtype,,,,X,X,X,Tux Typing,,Tecla Tux,Tecla Tux,,Typing game,,,,,,tuxtype -t,,tuxtype -t espanol,tuxtype -t brazilian-portuguese,,tuxtyping,,,,,Games,,,
-typing,work:60,work:60,work:60,X,X,X,Typing,,Tecla-Oke,Tecla-Okê,学习型,Learn to type,,,,,eos-typing,gjs /usr/share/eos-typing/src/endless_typing.js,,,,,typing,,,,,Education,Games,,
-weather,news:10,news:10,,X,X,,Weather,,Tiempo,Tempo,,See the weather forecast,,,,,,endless-os-weather,,,,,weather,,,,,Network,News,,
-wikipedia,curiosity:10,curiosity:10,curiosity:10,X,X,X,Wikipedia,,,Wikipédia,,Wikipedia,,,,,,eos-wikipedia,,,,,wikipedia-app,,,,,Education,,,
-youtube,30,30,30,X,X,X,YouTube,,,,,YouTube,,,,,,eos-youtube,,,,,youtube-app,,,,,Media,,,
+Id,Desktop,Desktop[Brazil],Desktop[Guatemala],AppStore,AppStore[Brazil],AppStore[Guatemala],Name,Name[en],Name[es],Name[pt],Name[zh],Comment,Comment[en],Comment[es],Comment[pt],Comment[zh],TryExec,Exec,Exec[en],Exec[es],Exec[pt],Exec[zh],Icon,Icon[en],Icon[es],Icon[pt],Icon[zh],Categories
+armagetron,,,,X,X,X,Armagetron,,Armagetron,Armagetron,,3d light cycle game,,,,,,armagetronad,,,,,armagetron-adv,,,,,Games;
+audacity,,,,X,X,X,Audio Editor,,Señor DJ,Edita Som,,Audacity,,,,,,audacity,,,,,audacity,,,,,Audio;
+billard-gl,,,,X,X,X,Billiards,,Billar,Sinuca,,BillardGL,,,,,,billard-gl,,,,,billardgl,,,,,Games;
+blockout2,,,,X,X,X,BlockOut 2,,BlockOut 2,BlockOut 2,,3D Tetris-style game,,,,,,blockout2,,,,,blockout2,,,,,Games;
+brazil,curiosity:15,curiosity:15,,X,X,,Brazil,,,Brasil,,Explore Brasil,,,,,eos-brazil,gjs /usr/share/eos-brazil/src/endless_brazil.js,,,,,brazil,,,,,Education;Travel;
+chromium-browser,10,10,10,X,X,X,Internet,,,,,Browse the Web,,,,,,chromium-browser %U,,,,,browser,,,,,Internet;
+chromium-bsu,games:60,games:60,games:60,X,X,X,Chromium BSU,,,,,Chromium BSU,,,,,chromium-bsu,resfix chromium-bsu --fullscreen,,,,,chromium-bsu,,,,,Games;
+english,curiosity:30,curiosity:30,curiosity:30,X,X,X,Learn English,,Aprende Inglés,Aprender Inglês,,Learn English,,,,,eos-english,gjs /usr/share/eos-english/src/english_app.js,,,,,english-app,,,,,Education;
+evolution,work:10,work:10,work:10,X,X,X,E-mail,,,,,E-mail,,,,,,evolution %U,,,,,email,,,,,Mail;Email;
+frostwire,media:40,media:40,media:40,X,X,X,Media Download,,Descargar,Baixar Mídia,,FrostWire,,,,,,frostwire,,,,,frostwire,,,,,Network;
+gcalctool,work:50,work:50,work:50,X,X,X,Calculator,,Calculadora,Calculadora,,Calculator,,,,,,gnome-calculator,,,,,calculator,,,,,Utility;Calculator;
+gcompris,curiosity:70,curiosity:70,curiosity:70,X,X,X,EduGames,,EduJuegos,Joginhos,教育游戏,GCompris childrens games,,,,,,gcompris,,,,,gcompris,,,,,Games;Education;
+gimp,media:50,media:50,media:50,X,X,X,GIMP,,,,,Photo Editor,,Editor de Imágenes,Editor de Imagens,图像编辑器,,gimp %U,,,,,gimp,,,,,Photos;
+gnome-genius,,,,X,X,X,Math,,Matemáticas,Matemática,,Genius Math,,,,,,gnome-genius,,,,,geniusmath,,,,,Utility;Calculator;
+gnome-sudoku,,,,X,X,X,Sudoku,,,,,Sudoku,,,,,,/usr/games/gnome-sudoku,,,,,sudoku,,,,,Games;
+goldendict,,,,X,X,X,Dictionary,,Dicionário,Dicionário,,GoldenDict,,,,,,goldendict,,,,,goldendict,,,,,Utility;
+health,curiosity:17,curiosity:17,,X,X,,Health,,Salud,Saúde,,Discover health,,,,,eos-health,gjs /usr/share/eos-health/src/endless_health.js,,,,,health,,,,,Education;
+khanacademy,curiosity:40,curiosity:40,curiosity:40,X,X,X,Khan Academy,,Academia Khan,Academia Khan,,Khan Academy,,,,,,eos-khanacademy,,,,,khanacademy-app,,,,,Education;
+kobodeluxe,,,,X,X,X,Kobo Deluxe,,Kobo Deluxe,Kobo Deluxe,,Destroy enemy bases in space,,,,,kobodl,resfix kobodl -fullscreen,,,,,kobodeluxe,,,,,Games;
+lbreakout2,,,,X,X,X,Breakout,,El Escape,Fuga,,LBreakout2 game,,,,,,lbreakout2,,,,,lbreakout,,,,,Games;
+libreoffice-calc,work:20,work:20,work:20,X,X,X,Spreadsheet,,Hoja de Cálculo,Planilha,,Spreadsheet,,,,,,libreoffice --calc %U,,,,,office_spreadsheet,,,,,Office;
+libreoffice-impress,work:30,work:30,work:30,X,X,X,Presentation,,Presentación,Apresentação,,Impress,,,,,,libreoffice --impress %U,,,,,office_presentation,,,,,Office;
+libreoffice-writer,50,50,50,X,X,X,Writer,,Escritor,Redator,,Writer,,,,,,libreoffice --writer %U,,,,,office_text,,,,,Office;
+nautilus,80,80,80,X,X,X,My Documents,,Documentos,Documentos,,File Manager,,,,,,nautilus,,,,,nautilus,,,,,FileManager;Utility;Core;GTK;
+numptyphysics,,,,X,X,X,Physics,,Retos,Fisicando,,Numpty Physics game,,,,,,numptyphysics,,,,,fisicando,,,,,Games;Education;
+openarena,games:10,games:10,games:10,X,X,X,Open Arena,,,,,Open Arena,,,,,/usr/games/openarena,resfix /usr/games/openarena,,,,,openarena,,,,,Games;
+photos,70,70,70,X,X,X,Photo Editor,,Editor de Fotos,Editor de Fotos,照片编辑器,Endless Photo App,,,,,,endless-os-photos %f,,,,,photo,,,,,Photos;
+pingus,,,,X,X,X,Pingus,,,,,Penguin Game,,,,,,pingus,,,,,pingus,,,,,Games;
+rhythmbox,media:30,media:30,media:30,X,X,X,Music,,Música,Música,,Music,,,,,,rhythmbox %U,,,,,music,,,,,Audio;
+shotwell,media:10,media:10,media:10,X,X,X,Photos,,Fotos,Fotos,,Shotwell Photo Organizer,,,,,,shotwell %U,,,,,shotwell,,,,,Photos;
+skype,40,40,40,X,X,X,Skype,,,,,Skype,,,,,,skype %U,,,,,skype,,,,,Network;
+sol,games:40,games:40,games:40,X,X,X,Freecell,,,,,Freecell,,,,,,/usr/games/sol --freecell,,,,,freecell,,,,,Games;
+solitaire,games:30,games:30,games:30,X,X,X,Solitaire,,,,,Solitaire,,,,,,/usr/games/sol --class=solitaire,,,,,solitaire,,,,,Games;
+stellarium,curiosity:80,curiosity:80,curiosity:80,X,X,X,Stellarium,,Constelaciones,Constelação,,Stellarium,,,,,,stellarium-wrapper,,,,,stellarium,,,,,Astronomy;Education;Science;
+supertux2,games:50,games:50,games:50,X,X,X,Super Tux,,,,,Super Tux,,,,,supertux2,resfix supertux2 --fullscreen,,,,,supertux,,,,,Games;
+supertuxkart,games:70,games:70,games:70,X,X,X,Tux Kart,,,,,Tux Kart,,,,,supertuxkart,resfix supertuxkart --fullscreen,,,,,supertuxkart,,,,,Games;
+teeworlds,,,,X,X,X,Teeworlds,,Teelandia,Teelândia,,Multiplayer game,,,,,teeworlds,resfix teeworlds,,,,,teelandia,,,,,Games;
+totem,media:20,media:20,media:20,X,X,X,Videos,,Vídeos,Vídeos,,Video,,,,,,totem %U,,,,,video,,,,,Video;
+translate,curiosity:20,curiosity:20,curiosity:20,X,X,X,Translate,,Traductor,Tradutor,翻译,Translate,,,,,,gjs /usr/share/eos-translation/translation_app.js,,,,,translate,,,,,Education;Office;
+tuxmath,,,,X,X,X,Tux Math,,123 Tux,123 Tux,,Math Games,,,,,,tuxmath,,,,,123tux,,,,,Games;Education;
+tuxtype,,,,X,X,X,Tux Typing,,Tecla Tux,Tecla Tux,,Typing game,,,,,,tuxtype -t,,tuxtype -t espanol,tuxtype -t brazilian-portuguese,,tuxtyping,,,,,Games;
+typing,work:60,work:60,work:60,X,X,X,Typing,,Tecla-Oke,Tecla-Okê,学习型,Learn to type,,,,,eos-typing,gjs /usr/share/eos-typing/src/endless_typing.js,,,,,typing,,,,,Education;Games;
+weather,news:10,news:10,,X,X,,Weather,,Tiempo,Tempo,,See the weather forecast,,,,,,endless-os-weather,,,,,weather,,,,,Network;News;
+wikipedia,curiosity:10,curiosity:10,curiosity:10,X,X,X,Wikipedia,,,Wikipédia,,Wikipedia,,,,,,eos-wikipedia,,,,,wikipedia-app,,,,,Education;
+youtube,30,30,30,X,X,X,YouTube,,,,,YouTube,,,,,,eos-youtube,,,,,youtube-app,,,,,Media;


### PR DESCRIPTION
Per the desktop entry spec, each category must end in a semicolon.
Somehow these had been replaced with commas.

[endlessm/eos-shell#831]
