### PR TITLE
Auto import user's media

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -96,3 +96,12 @@ switch-windows=['<Alt>Tab']
 # Set Exploration Center as browser homepage
 [com.endlessm.eos-browser]
 homepage-url='file:///usr/share/EndlessOS/exploration_center/index.html'
+
+# Automatically import user's pictures into Shotwell
+[org.yorba.shotwell.preferences.files]
+auto-import=true
+
+# Automatically import user's music into Rhythmbox
+[org.gnome.rhythmbox.rhythmdb]
+monitor-library=true
+


### PR DESCRIPTION
For Shotwell, the upstream default of auto-import is false,
so this is necessary to enable that feature by default.

For Rhythmbox, the upstream default of monitor-library is true,
but we explicitly set it here for consistency
(and just in case the upstream default were to change).

In either case, we don't explicitly set the import location,
as the upstream defaults properly point to the user's home folders,
and any attempt to explicitly set the folder name would
not properly handle translations of the home folder names.

[endlessm/eos-shell#849]
