### PR TITLE
Apps that request no title bar when maximized now retain the bar when tiled

### DIFF
--- a/themes/EndlessOS/metacity-1/metacity-theme-1.xml
+++ b/themes/EndlessOS/metacity-1/metacity-theme-1.xml
@@ -445,7 +445,7 @@
   <frame focus="yes" state="normal" resize="both" style="utility_focused"/>
   <frame focus="no" state="normal" resize="both" style="utility_unfocused"/>
   <frame focus="yes" state="maximized" style="maximized_focused"/>
-  <frame focus="no" state="maximized" style="normal_focused"/>
+  <frame focus="no" state="maximized" style="maximized_unfocused"/>
   <frame focus="yes" state="shaded" style="normal_focused"/>
   <frame focus="no" state="shaded" style="normal_unfocused"/>
   <frame focus="yes" state="maximized_and_shaded" style="maximized_focused"/>
@@ -456,11 +456,15 @@
   <frame focus="yes" state="normal" resize="both" style="border"/>
   <frame focus="no" state="normal" resize="both" style="border"/>
   <frame focus="yes" state="maximized" style="maximized_focused"/>
-  <frame focus="no" state="maximized" style="normal_focused"/>
+  <frame focus="no" state="maximized" style="maximized_unfocused"/>
   <frame focus="yes" state="shaded" style="normal_focused"/>
   <frame focus="no" state="shaded" style="normal_unfocused"/>
   <frame focus="yes" state="maximized_and_shaded" style="maximized_focused"/>
   <frame focus="no" state="maximized_and_shaded" style="maximized_unfocused"/>
+  <frame focus="yes" state="tiled_left" style="maximized_focused"/>
+  <frame focus="no" state="tiled_left" style="maximized_unfocused"/>
+  <frame focus="yes" state="tiled_right" style="maximized_focused"/>
+  <frame focus="no" state="tiled_right" style="maximized_unfocused"/>
 </frame_style_set>
 
 <!-- window -->


### PR DESCRIPTION
The theme was already set to ignore requests by apps to hide the
title bar when they are maximized. However, when apps chose to
hide the title bar when maximized, the title bar would in fact be
hidden when the app was tiled to the left or right.

This patch also fixes a problem where the style looked slightly
weird on some apps that were maximized but not focused, which
appears to be due to a copy/paste error in the theme.

[endlessm/eos-shell#989]
