### PR TITLE
Add topbar-refresh-symbolic.svg for the social bar

### DIFF
--- a/icons/scalable/actions/topbar-refresh-symbolic.svg
+++ b/icons/scalable/actions/topbar-refresh-symbolic.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Google_x2B_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="16px" height="16px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+<path d="M13,8c0,0,0,0.329,0,0.5c0,2.485-2.015,4.5-4.5,4.5S4,10.985,4,8.5C4,6.186,5.753,4.252,8,4v2l4.5-3L8,0v2
+	C4.645,2.256,2,5.079,2,8.5C2,12.09,4.91,15,8.5,15S15,12.09,15,8.5C15,8.331,15,8,15,8H13z"/>
+</svg>


### PR DESCRIPTION
Adds the icon `topbar-refresh-symbolic.svg`, which is used in the reload button of the social bar.

See endlessm/eos-shell#811 for details.
