### PR TITLE
Depend on gtk2-engines-pixbuf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,9 +24,9 @@ Package: eos-theme
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         gtk2-engines-pixbuf,
          eos-shell
-Recommends: gtk2-engines,
-            eos-plymouth-theme,
+Recommends: eos-plymouth-theme,
             eos-shell
 Description: Custom theme for eos-shell
  Custom theme along with icons and images


### PR DESCRIPTION
This is needed for the GTK2 theme to work properly.

[endlessm/eos-shell#1202]
