### PR TITLE
Generate per-personality json files for desktop icon layout

### DIFF
--- a/desktop/Makefile.am
+++ b/desktop/Makefile.am
@@ -33,8 +33,8 @@ links_DATA = $(wildcard $(srcdir)/links/*.desktop)
 foldersdir = $(datadir)/desktop-directories
 folders_DATA = $(wildcard $(srcdir)/folders/*.directory)
 
-desktopsdir = $(datadir)/EndlessOS/desktops
-desktops_DATA = $(wildcard settings/com.endlessm.desktop.*.gschema.override)
+desktopsdir = $(datadir)/EndlessOS/personality-defaults
+desktops_DATA = $(wildcard settings/icon-grid-*.json)
 
 bin_SCRIPTS = eos-exec-localized eos-select-personality
 

--- a/desktop/eos-select-personality.in
+++ b/desktop/eos-select-personality.in
@@ -23,7 +23,7 @@ const OVERRIDES_PRIORITY = 90;
 const selectPersonality = function() {
     let command = 'zenity --list --title="Desktop configuration" --text="Select an option and hit OK\n(Cancel to keep existing configuration)" --radiolist --hide-header --column=button --column=selection TRUE default';
 
-    let path = INSTALL_PATH + '/EndlessOS/desktops';
+    let path = INSTALL_PATH + '/EndlessOS/personality-defaults';
     let dir = Gio.File.new_for_path(path);
 
     let files;
@@ -31,7 +31,7 @@ const selectPersonality = function() {
         files = dir.enumerate_children('standard::name,standard::type',
                                        Gio.FileQueryInfoFlags.NONE, null);
     } catch (e) {
-        logError(e, 'Missing desktop configuration files in ' + path);
+        logError(e, 'Missing personality configuration files in ' + path);
         return null;
     }
 
@@ -39,11 +39,14 @@ const selectPersonality = function() {
 
     while (file) {
         let name = file.get_name();
-        // Example: com.endlessm.desktop.Brazil.gschema.override
-        let tokens = name.split('.');
-        const PERSONALITY_INDEX = 3;
-        let option = tokens[PERSONALITY_INDEX];
-        command += ' FALSE ' + option;
+        // Example: icon-grid-Brazil.json
+        let tokens = name.match(/^icon-grid-(.*).json$/);
+        if (tokens !== null) {
+            let option = tokens[1];
+            if (option != 'default') {
+                command += ' FALSE ' + option;
+            }
+        }
         file = files.next_file(null);
     }
 

--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -2,17 +2,14 @@ EXTRA_DIST = com.endlessm.settings.gschema.override.in
 
 do_subst = sed -e 's|@DATA_DIR[@]|$(datadir)|g'
 
-com.endlessm.settings.gschema.override: com.endlessm.settings.gschema.override.in
+50_eos-theme.gschema.override: com.endlessm.settings.gschema.override.in
 	$(AM_V_GEN) $(do_subst) $< > $@
-50_eos-theme.gschema.override: com.endlessm.settings.gschema.override $(top_builddir)/desktop/settings/com.endlessm.desktop.gschema.override
-	$(AM_V_GEN) cat com.endlessm.settings.gschema.override $(top_builddir)/desktop/settings/com.endlessm.desktop.gschema.override > $@
 
 settingsdir = $(datadir)/glib-2.0/schemas
 settings_DATA = \
 	50_eos-theme.gschema.override
 
 CLEANFILES = \
-	$(settings_DATA) \
-	com.endlessm.settings.gschema.override
+	$(settings_DATA)
 
 @GSETTINGS_RULES@

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -109,3 +109,7 @@ auto-import=true
 [org.gnome.rhythmbox.rhythmdb]
 monitor-library=true
 
+# Default desktop layout. An empty value indicates that the real per-personality
+# default stored in usr/share/EndlessOS/personality-defaults/ should be used
+[org.gnome.shell]
+icon-grid-layout={}


### PR DESCRIPTION
Generates json files containing the correct desktop icon layout
for each personality in csv_to_desktop.py. Also modifies
eos-select-personality to look for these files to determine which
personalities are available.

[endlessm/eos-shell#1262]
