### PR TITLE
Use 'desktop' as ID for the toplevel grid

### DIFF
--- a/desktop/csv_to_desktop.py
+++ b/desktop/csv_to_desktop.py
@@ -324,9 +324,9 @@ class DesktopLayout:
 
             desktop = layout['desktop']
             sorted_desktop = sorted(desktop, key = lambda val: int(val))
-            settings_dict[''] = []
+            settings_dict['desktop'] = []
             for item in sorted_desktop:
-                settings_dict[''].append(desktop[item])
+                settings_dict['desktop'].append(desktop[item])
 
             # Process the folders in the order that they appear on the desktop
             folders = layout['folders']


### PR DESCRIPTION
Parsing the JSon file from the Shell side will fail when the key is the
empty string.

[endlessm/eos-shell#1337]
