### PR TITLE
Fix test for Stellarium installation

### DIFF
--- a/desktop/applications.csv
+++ b/desktop/applications.csv
@@ -42,7 +42,7 @@ shotwell,media:10,media:10,media:10,X,X,X,Photos,,Fotos,Fotos,,Shotwell Photo Or
 skype,40,40,40,X,X,X,Skype,,,,,Skype,,,,,,skype %U,,,,,skype,,,,,none,Network;
 sol,games:40,games:40,games:40,X,X,X,Freecell,,,,,Freecell,,,,,,/usr/games/sol --variation=freecell,,,,,freecell,,,,,,Games;
 solitaire,games:30,games:30,games:30,X,X,X,Solitaire,,,,,Solitaire,,,,,,/usr/games/sol --class=solitaire --variation=klondike,,,,,solitaire,,,,,,Games;
-stellarium,curiosity:80,curiosity:80,curiosity:80,X,X,X,Stellarium,,Constelaciones,Constelação,,Stellarium,,,,,,stellarium-wrapper,,,,,stellarium,,,,,,Astronomy;Education;Science;
+stellarium,curiosity:80,curiosity:80,curiosity:80,X,X,X,Stellarium,,Constelaciones,Constelação,,Stellarium,,,,,stellarium,stellarium-wrapper,,,,,stellarium,,,,,,Astronomy;Education;Science;
 supertux2,games:50,games:50,games:50,X,X,X,Super Tux,,,,,Super Tux,,,,,supertux2,resfix supertux2 --fullscreen,,,,,supertux,,,,,,Games;
 supertuxkart,games:70,games:70,games:70,X,X,X,Tux Kart,,,,,Tux Kart,,,,,supertuxkart,resfix supertuxkart --fullscreen,,,,,supertuxkart,,,,,,Games;
 teeworlds,,,,X,X,X,Teeworlds,,Teelandia,Teelândia,,Multiplayer game,,,,,teeworlds,resfix teeworlds,,,,,teelandia,,,,,,Games;


### PR DESCRIPTION
Stellarium is run via a wrapper script,
so we need a TryExec to check if the application is installed.
Fixes problem where Stellarium shows up on desktop
on Odroid, even though it was not build for ARM.

[endlessm/eos-shell#1359]
