### PR TITLE
Fix weblink typo for riovestibular

### DIFF
--- a/desktop/links.csv
+++ b/desktop/links.csv
@@ -69,7 +69,7 @@ riocontra,,,,,X,,Rio Contra Dengue,,,,,,,,,,http://ww.riocontradengue.rj.gov.br/
 rioshow,,,,,X,,Rio Show,,,,,,,,,,http://rioshow.oglobo.globo.com/aspx/geral/home_principal.aspx?gclid=CK-2r7-inLMCFRRbnAodgBwA9w,,,,,rioshow,,,,,Rio;
 rioturismoradical,,,,,X,,Rio Turismo Radical,,,,,,,,,,http://www.rioturismoradical.com.br/portugues/index1.htm,,,,,turismo-radical,,,,,Rio;
 riovagas,,,,,X,,Rio Vagas,,,,,,,,,,http://www.riovagas.com.br,,,,,rio-vagas,,,,,Jobs;
-rivestibular,,,,,X,,Rio Vestibular,,,,,,,,,,http://www.rivestibular.com.br,,,,,vestibular,,,,,Health;Education;
+riovestibular,,,,,X,,Rio Vestibular,,,,,,,,,,http://www.riovestibular.com.br,,,,,vestibular,,,,,Health;Education;
 saudeterra,,,,,X,,Saúde Terra,,,,,,,,,,http://saude.terra.com.br,,,,,saude-terra,,,,,Health;Education;
 seguros,,,,,X,,Seguros,,,,,,,,,,http://www.superqualidadeseguros.com,,,,,sq-seguros,,,,,Health;Education;
 senac,,,,,X,,Senac,,,,,,,,,,http://www.rj.senac.br,,,,,senac-rj,,,,,Health;Education;


### PR DESCRIPTION
Previously was incorrectly using rivestibular.

[endlessm/eos-shell#1074]
