### PR TITLE
Remove button to log in as another user from the lock screen

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -6,6 +6,10 @@ dynamic-workspaces=false
 [org.gnome.desktop.wm.preferences]
 num-workspaces=1
 
+# Disable switching users from the lock screen
+[org.gnome.desktop.screensaver]
+user-switch-enabled=false
+
 # Force the app menu to be on the application window rather than the shell panel
 # (required due to removal of the app menu from the panel)
 [org.gnome.settings-daemon.plugins.xsettings]


### PR DESCRIPTION
[endlessm/eos-shell#1492]
