### PR TITLE
Added background image links for Global

### DIFF
--- a/backgrounds/Makefile.am
+++ b/backgrounds/Makefile.am
@@ -9,14 +9,16 @@ default_images = $(datadir)/eos-media/default_images
 
 install-data-hook:
 	$(mkdir_p) $(DESTDIR)$(datadir)/EndlessOS/personality-defaults
-	ln -fs $(default_images)/bg_guatemala_09.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-default.jpg
-	ln -fs $(default_images)/bg_guatemala_09.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
+	ln -fs $(default_images)/bg_global_01.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-default.jpg
 	ln -fs $(default_images)/bg_brazil_13.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Brazil.jpg
+	ln -fs $(default_images)/bg_global_01.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Global.jpg
+	ln -fs $(default_images)/bg_guatemala_09.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
 
 uninstall-hook:
 	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-default.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
 	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Brazil.jpg
+	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Global.jpg
+	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
 
 metadatadir = $(datadir)/gnome-background-properties
 metadata_DATA = endlessos.xml

--- a/backgrounds/endlessos.xml.in.in
+++ b/backgrounds/endlessos.xml.in.in
@@ -10,16 +10,24 @@
     <scolor>#000000</scolor>
   </wallpaper>
   <wallpaper deleted="false">
-    <_name>Default Background Guatemala</_name>
-    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg</filename>
+    <_name>Default Background Brazil</_name>
+    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-Brazil.jpg</filename>
     <options>zoom</options>
     <shade_type>solid</shade_type>
     <pcolor>#3465a4</pcolor>
     <scolor>#000000</scolor>
   </wallpaper>
   <wallpaper deleted="false">
-    <_name>Default Background Brazil</_name>
-    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-Brazil.jpg</filename>
+    <_name>Default Background Global</_name>
+    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-Global.jpg</filename>
+    <options>zoom</options>
+    <shade_type>solid</shade_type>
+    <pcolor>#3465a4</pcolor>
+    <scolor>#000000</scolor>
+  </wallpaper>
+  <wallpaper deleted="false">
+    <_name>Default Background Guatemala</_name>
+    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg</filename>
     <options>zoom</options>
     <shade_type>solid</shade_type>
     <pcolor>#3465a4</pcolor>


### PR DESCRIPTION
Also use Global's image as the default rather than Guatemala's.

[endlessm/eos-shell#1574]
