### PR TITLE
Issues/1947

### DIFF
--- a/themes/EndlessOS/metacity-1/metacity-theme-1.xml
+++ b/themes/EndlessOS/metacity-1/metacity-theme-1.xml
@@ -48,14 +48,14 @@
 </frame_geometry>
 
 <frame_geometry name="border" has_title="false">
-  <distance name="left_width" value="3"/>
-  <distance name="right_width" value="3"/>
-  <distance name="bottom_height" value="3"/>
+  <distance name="left_width" value="0"/>
+  <distance name="right_width" value="0"/>
+  <distance name="bottom_height" value="0"/>
   <distance name="left_titlebar_edge" value="0"/>
   <distance name="right_titlebar_edge" value="0"/>
   <distance name="button_width" value="0"/>
   <distance name="button_height" value="0"/>
-  <distance name="title_vertical_pad" value="3"/>
+  <distance name="title_vertical_pad" value="0"/>
   <border name="title_border" left="0" right="0" top="0" bottom="0"/>
   <border name="button_border" left="0" right="0" top="0" bottom="0"/>
 </frame_geometry>


### PR DESCRIPTION
Make the `"border"` window style be empty.

The `"border"` style set is used by modal attached dialogs in this version of the Mutter theme. Since their parent window is faded by the Shell, a visible border doesn't look good.

This case is managed by the `"attached"` window type in later versions of the Mutter theme format.

See endlessm/eos-shell#1947 for details.
