### PR TITLE
Change font antialiasing to grayscale

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -41,7 +41,7 @@ monospace-font-name='Ubuntu Mono 13'
 titlebar-font='Lato Bold 13'
 
 [org.gnome.settings-daemon.plugins.xsettings]
-antialiasing='rgba'
+antialiasing='grayscale'
 hinting='slight'
 
 # Remove the Ubuntu overlay scrollbars


### PR DESCRIPTION
Using 'rgba' antialiasing can cause TV monitors to render fonts as
entirely red, green, or blue. Switching to grayscale font antialiasing
fixes the problem with little other difference between the two types
of antialiasing. The antialiasing problem will likely occur for many
low-end TVs, especially if they are already overscanning or
misconfiguring the pixel order (i.e. 'rgb' vs 'bgr'). Switched the
gsetting antialiasing to grayscale in our gsettings override.

[endlessm/eos-shell#2028]
