### PR TITLE
Issues/740

### DIFF
--- a/themes/EndlessOS/gtk-3.0/endless-widgets.css
+++ b/themes/EndlessOS/gtk-3.0/endless-widgets.css
@@ -45,3 +45,10 @@
 .top-bar .button *:active {
     color: #8a8a8a;
 }
+
+/* Shadow beneath the top bar */
+.mutter-topbar-shadow {
+  border-width: 2px;
+  border-style: solid;
+  border-color: alpha(black, 0.15);
+}


### PR DESCRIPTION
Define the class `"mutter-topbar-shadow"`, used by the window manager to paint a shadow beneath a window's title bar.

See endlessm/eos-shell#704 for details.
