### PR TITLE
Add gsettings overrides for xdg-user-dirs

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -103,3 +103,9 @@ autorun-x-content-start-app=['x-content/unix-software', 'x-content/video-dvd']
 # Hide EOG sidebar by default
 [org.gnome.eog.ui]
 sidebar=false
+
+# On change of language, move home directories rather than copy,
+# without asking the user for confirmation
+[org.gnome.xdg-user-dirs]
+move-directories=true
+show-confirmation-dialog=false


### PR DESCRIPTION
On change of language, move home directories rather than copy,
without asking the user for confirmation.

[endlessm/eos-shell#2159]
