### PR TITLE
settings: always set scaling-factor to 1

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -109,3 +109,7 @@ sidebar=false
 [org.gnome.xdg-user-dirs]
 move-directories=true
 show-confirmation-dialog=false
+
+# Always turn off scaling factor, as we don't fully support it yet
+[org.gnome.desktop.interface]
+scaling-factor=1


### PR DESCRIPTION
Avoid surprises when connecting to displays that don't properly report
their size. Our stack doesn't fully support HiDpi yet anyway.

[endlessm/eos-shell#2710]
