### PR TITLE
Updated symbolic icons for topbar navigation

### DIFF
--- a/icons/scalable/actions/topbar-go-next-symbolic.svg
+++ b/icons/scalable/actions/topbar-go-next-symbolic.svg
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Google_x2B_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" width="16px" height="16px" viewBox="-0.5 0.5 16 16" enable-background="new -0.5 0.5 16 16" xml:space="preserve">
-<path d="M13.5,8.001L6.845,1.5L5.009,3.562L8.053,6.5H1.5v3h6.553l-2.998,2.915l1.81,2.087L13.5,8.001z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+  xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"
+  width="16" height="16" viewBox="0 0 16 16" version="1.1">
+  <!-- Generator: Sketch 3.0.1 (7597) - http://www.bohemiancoding.com/sketch -->
+  <path style="fill:#bababa;fill-opacity:1;stroke:none"
+    d="m 11.122955,8.0031637 c -3.08e-4,0.2547451 -0.09809,0.5089019 -0.292427,0.7032361 L 6.5836869,12.953241 C 6.1990278,13.3379 5.5620979,13.341665 5.1715734,12.951141 4.7783266,12.557894 4.780112,11.928388 5.1694734,11.539027 L 8.7071073,8.0013931 5.1694733,4.4637591 C 4.7848114,4.0790972 4.7810525,3.4421666 5.1715734,3.0516456 5.5648238,2.6583953 6.1943227,2.6601814 6.5836869,3.0495455 l 4.2468411,4.2468409 c 0.191987,0.1919866 0.289087,0.4468144 0.289644,0.7024809 z"/>
 </svg>

--- a/icons/scalable/actions/topbar-go-previous-symbolic.svg
+++ b/icons/scalable/actions/topbar-go-previous-symbolic.svg
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Google_x2B_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" width="16px" height="16px" viewBox="-0.5 0.5 16 16" enable-background="new -0.5 0.5 16 16" xml:space="preserve">
-<path d="M8.135,14.502l1.81-2.087L6.947,9.5H13.5v-3H6.947l3.044-2.938L8.155,1.5L1.5,8.001L8.135,14.502z"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg"
+  width="16" height="16" viewBox="0 0 16 16" version="1.1">
+  <!-- Generator: Sketch 3.0.1 (7597) - http://www.bohemiancoding.com/sketch -->
+  <path style="fill:#bababa;fill-opacity:1;stroke:none"
+    d="M 4.8770454,7.9968363 C 4.8773529,7.7420905 4.975138,7.4879344 5.1694722,7.2936002 L 9.4163131,3.0467593 c 0.384659,-0.384659 1.0215889,-0.3884243 1.4121139,0.0021 0.393246,0.3932468 0.391461,1.0227522 0.0021,1.4121135 l -3.5376344,3.537634 3.5376344,3.5376342 c 0.384661,0.384662 0.38842,1.021593 -0.0021,1.412114 -0.393251,0.39325 -1.0227498,0.391464 -1.4121139,0.0021 L 5.1694722,8.7036136 C 4.9774856,8.511627 4.880385,8.2567991 4.8798285,8.0011327 z"/>
 </svg>


### PR DESCRIPTION
New standard designs for topbar navigation browser buttons. Put in
place for the knowledge apps, but applies to other apps as well.

[endlessm/eos-sdk#1294]
