### PR TITLE
Add browser and file manager to dash by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -51,9 +51,9 @@ button-layout=':maximize,minimize,close'
 [org.gnome.desktop.background]
 picture-uri='eos:///default'
 
-# Specify the favorites on the dash (should be empty by default)
+# Specify the favorites on the dash (default to browser and file manager)
 [org.gnome.shell]
-favorite-apps=[]
+favorite-apps=['eos-app-chromium-browser.desktop', 'eos-app-eos-file-manager.desktop']
 
 # Always enable log out
 [org.gnome.shell]


### PR DESCRIPTION
[endlessm/eos-shell#2471]
