### PR TITLE
gtk3: backport a fix for GTK 3.12

### DIFF
--- a/themes/EndlessOS/gtk-3.0/gtk-widgets.css
+++ b/themes/EndlessOS/gtk-3.0/gtk-widgets.css
@@ -137,7 +137,11 @@ GtkClutterOffscreen {
 GtkImage,
 GtkImage:insensitive,
 GtkLabel,
-GtkLabel:insensitive {
+GtkLabel:insensitive,
+GtkBox,
+GtkBox:insensitive,
+GtkGrid,
+GtkGrid:insensitive {
     background-color: transparent;
 }
 


### PR DESCRIPTION
Make sure we don't use a background on these widgets.
They started rendering a background in 3.12.

[endlessm/eos-shell#3004]
