### PR TITLE
Revert to default touchpad scrolling rather than 'natural'

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -71,10 +71,6 @@ restore-session-policy='never'
 [org.gnome.settings-daemon.peripherals.mouse]
 drag-threshold=10
 
-# Enable touchpad natural scrolling by default
-[org.gnome.settings-daemon.peripherals.touchpad]
-natural-scroll=true
-
 # Disable the switch user option on the user menu
 [org.gnome.desktop.lockdown]
 disable-user-switching=true


### PR DESCRIPTION
[endlessm/eos-shell#3211]
