### PR TITLE
Use Ctrl-Q to quit

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -109,3 +109,7 @@ show-confirmation-dialog=false
 # Always turn off scaling factor, as we don't fully support it yet
 [org.gnome.desktop.interface]
 scaling-factor=1
+
+# Use Ctrl-Q as alternative to quit applications
+[org.gnome.desktop.wm.keybindings]
+close=['<Alt>F4', '<Ctrl>Q']


### PR DESCRIPTION
Besides default Alt+F4, let's use Ctrl+Q to close applications.

[endlessm/eos-shell#3477]
