### PR TITLE
settings: add GSettings override for search providers order

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -113,3 +113,7 @@ scaling-factor=1
 # Use Ctrl-Q as alternative to quit applications
 [org.gnome.desktop.wm.keybindings]
 close=['<Alt>F4', '<Ctrl>Q']
+
+# Override the order for default search providers
+[org.gnome.desktop.search-providers]
+sort-order=['com.endlessm.encyclopedia-es.desktop', 'com.endlessm.encyclopedia-pt.desktop', 'com.endlessm.encyclopedia-ar.desktop', 'com.endlessm.encyclopedia-fr.desktop', 'com.endlessm.encyclopedia-en.desktop', 'eos-file-manager.desktop']


### PR DESCRIPTION
[endlessm/eos-shell#3672]
