### PR TITLE
backgrounds: install default bgs per language and not per personality

### DIFF
--- a/backgrounds/Makefile.am
+++ b/backgrounds/Makefile.am
@@ -8,23 +8,15 @@ endlessos-backgrounds-default.xml.in: endlessos-backgrounds-default.xml.in.in
 default_images = $(datadir)/eos-media/default_images
 
 install-data-hook:
-	$(mkdir_p) $(DESTDIR)$(datadir)/EndlessOS/personality-defaults
-	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-default.jpg
-	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Arabic.jpg
-	ln -fs $(default_images)/bg_brazil_01.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Brazil.jpg
-	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Global.jpg
-	ln -fs $(default_images)/bg_global_01.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
-	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Haiti.jpg
-	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Spanish.jpg
+	$(mkdir_p) $(DESTDIR)$(datadir)/EndlessOS/language-defaults
+	ln -fs $(default_images)/bg_global_02.jpg $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-C.jpg
+	ln -fs $(default_images)/bg_global_01.jpg $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-es_GT.jpg
+	ln -fs $(default_images)/bg_brazil_01.jpg $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-pt.jpg
 
 uninstall-hook:
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-default.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Arabic.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Brazil.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Global.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Guatemala.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Haiti.jpg
-	rm -f $(DESTDIR)$(datadir)/EndlessOS/personality-defaults/desktop-background-Spanish.jpg
+	rm -f $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-C.jpg
+	rm -f $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-es_GT.jpg
+	rm -f $(DESTDIR)$(datadir)/EndlessOS/language-defaults/desktop-background-pt.jpg
 
 metadatadir = $(datadir)/gnome-background-properties
 metadata_DATA = endlessos-backgrounds-default.xml

--- a/backgrounds/endlessos-backgrounds-default.xml.in.in
+++ b/backgrounds/endlessos-backgrounds-default.xml.in.in
@@ -3,7 +3,7 @@
 <wallpapers>
   <wallpaper deleted="false">
     <_name>Default Background</_name>
-    <filename>@DATA_DIR@/EndlessOS/personality-defaults/desktop-background-default.jpg</filename>
+    <filename>@DATA_DIR@/EndlessOS/language-defaults/desktop-background-C.jpg</filename>
     <options>zoom</options>
     <shade_type>solid</shade_type>
     <pcolor>#3465a4</pcolor>


### PR DESCRIPTION
This will help removing a dependency on the Endless SDK library from
some core OS components.

[endlessm/eos-shell#4831]