### PR TITLE
Set env var to disable gtk overlay scrolling

### DIFF
--- a/settings/65gtk-overlay-scrolling
+++ b/settings/65gtk-overlay-scrolling
@@ -1,0 +1,5 @@
+# Copyright 2015 Endless Mobile, Inc.
+# This file is sourced by Xsession(5), not executed.
+
+# Always show full scrollbars (turn off gtk overlay scrolling).
+export GTK_OVERLAY_SCROLLING=0

--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -1,5 +1,3 @@
-EXTRA_DIST = com.endlessm.settings.gschema.override.in
-
 do_subst = sed -e 's|@DATA_DIR[@]|$(datadir)|g'
 
 50_eos-theme.gschema.override: com.endlessm.settings.gschema.override.in
@@ -8,6 +6,13 @@ do_subst = sed -e 's|@DATA_DIR[@]|$(datadir)|g'
 settingsdir = $(datadir)/glib-2.0/schemas
 settings_DATA = \
 	50_eos-theme.gschema.override
+
+xsessiondir = $(sysconfdir)/X11/Xsession.d
+xsession_DATA = 65gtk-overlay-scrolling
+
+EXTRA_DIST = \
+	com.endlessm.settings.gschema.override.in \
+	$(xsession_DATA)
 
 CLEANFILES = \
 	$(settings_DATA)


### PR DESCRIPTION
Based on user research, we've found that many users in our target market
are confused by thin/disappearing scroll bars.  With the new overlay
scrolling feature in GTK+, we need to explicitly disable this feature
to retain our current scrollbar theme.

[endlessm/eos-shell#5215]