### PR TITLE
Install into /etc/X11/Xsession.d

### DIFF
--- a/debian/eos-theme.install
+++ b/debian/eos-theme.install
@@ -1,3 +1,4 @@
+etc/X11/Xsession.d
 usr/share/themes/EndlessOS
 usr/share/icons/EndlessOS
 usr/share/fonts/EndlessOS


### PR DESCRIPTION
Used to set an environment variable to disable gtk overlay scrolling.

[endlessm/eos-shell#5215-debian]