### PR TITLE
Remove default dash favorites

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -43,10 +43,6 @@ button-layout=':minimize,maximize,close'
 [org.gnome.desktop.background]
 picture-uri='eos:///default'
 
-# Specify the favorites on the dash (default to browser and file manager)
-[org.gnome.shell]
-favorite-apps=['chromium-browser.desktop', 'eos-file-manager.desktop']
-
 # Always enable log out
 [org.gnome.shell]
 always-show-log-out=true


### PR DESCRIPTION
Now that we have added pinning to the taskbar, and we are considering
removing the dash favorites feature altogether in the future, we no
longer want to encourage use of the dash for favorites.

[endlessm/eos-shell#6319]