### PR TITLE
Remove gnome-background-properties from install file

### DIFF
--- a/debian/eos-theme.install
+++ b/debian/eos-theme.install
@@ -2,4 +2,3 @@ etc/X11/Xsession.d
 usr/share/themes/EndlessOS
 usr/share/icons/EndlessOS
 usr/share/fonts/EndlessOS
-usr/share/gnome-background-properties


### PR DESCRIPTION
To match commit 19cfe4ea. Without this, the OBS build fails:

dh_install: eos-theme missing files: usr/share/gnome-background-properties

https://phabricator.endlessm.com/T11083