### PR TITLE
settings: fix file manager search provider override

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -103,7 +103,7 @@ close=['<Alt>F4', '<Ctrl>Q']
 # Override the order for default search providers
 [org.gnome.desktop.search-providers]
 sort-order=['com.endlessm.encyclopedia-es.desktop', 'com.endlessm.encyclopedia-pt.desktop', 'com.endlessm.encyclopedia-ar.desktop', 'com.endlessm.encyclopedia-fr.desktop', 'com.endlessm.encyclopedia-en.desktop']
-disabled=['eos-app-eos-file-manager.desktop']
+disabled=['org.gnome.Nautilus.desktop']
 
 # Include Endless sample media in the directories indexed by tracker
 # (tracker does not follow symlinks, so we need the absolute path


### PR DESCRIPTION
This was missed when we switched back to Nautilus.

https://phabricator.endlessm.com/T11491