### PR TITLE
T11564: settings: Change touchpad click-method to fingers

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -110,3 +110,8 @@ disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop', 'gnote.deskt
 # even though they are linked from the xdg user directories)
 [org.freedesktop.Tracker.Miner.Files]
 index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&PICTURES', '&VIDEOS', '/var/endless-content']
+
+# Enable right-click and middle-click when clicking the touchpad (as opposed to
+# just when using tap-to-click)
+[org.gnome.desktop.peripherals.touchpad]
+click-method='fingers'


### PR DESCRIPTION
This enables right-click and middle-click when clicking the touchpad (as
opposed to just tapping).

https://phabricator.endlessm.com/T11564