### PR TITLE
Revert "settings: Change touchpad click-method to fingers"

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -110,8 +110,3 @@ disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop', 'gnote.deskt
 # even though they are linked from the xdg user directories)
 [org.freedesktop.Tracker.Miner.Files]
 index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&PICTURES', '&VIDEOS', '/var/endless-content']
-
-# Enable right-click and middle-click when clicking the touchpad (as opposed to
-# just when using tap-to-click)
-[org.gnome.desktop.peripherals.touchpad]
-click-method='fingers'


### PR DESCRIPTION
This reverts commit c881b7a4b5b3b834ce70584f6ac42236532982cf.

libinput provides software buttons emulation using either the number of
fingers touching the pad (also called clickfinger behavior), or the area
of the touchpad defined for left/right buttons, but not both at the same
time as the older Synaptics driver does.

The "default" value is not a libinput default (which would be the same
for all touchpads), but a device-specific default: clickfinger behavior
is only enabled on Apple touchpads, and areas on others.

To avoid confusing all users that have markings on their touchpads
defining button areas, lets revert this back to the default.

https://phabricator.endlessm.com/T11564