### PR TITLE
settings: don't use special URI for default background

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -39,7 +39,7 @@ button-layout=':minimize,maximize,close'
 
 # Specify the default background image
 [org.gnome.desktop.background]
-picture-uri='eos:///default'
+picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 
 # Always enable log out
 [org.gnome.shell]


### PR DESCRIPTION
Instead, just set it to the one for the C locale. Other personalities
will have their default set using a dconf override.

https://phabricator.endlessm.com/T10782