### PR TITLE
settings: disable gnome-software folder management

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -116,3 +116,4 @@ index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&
 [org.gnome.software]
 show-nonfree-ui=false
 enable-software-sources=false
+show-folder-management=false


### PR DESCRIPTION
We don't want this by default.

https://phabricator.endlessm.com/T11689