### PR TITLE
Move Rhythmbox override out of Rhythmbox package

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -123,3 +123,7 @@ show-nonfree-software=true
 # Remove default screencast duration limit
 [org.gnome.settings-daemon.plugins.media-keys]
 max-screencast-length=0
+
+# Make Rhythmbox seem less like a database management app
+[org.gnome.rhythmbox.source]
+show-browser=false


### PR DESCRIPTION
eos-theme seems like a better place for this preference.