### PR TITLE
settings: Override GNOME Software's download-updates

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -119,6 +119,7 @@ enable-software-sources=false
 show-folder-management=false
 show-nonfree-prompt=false
 show-nonfree-software=true
+download-updates=false
 
 # Remove default screencast duration limit
 [org.gnome.settings-daemon.plugins.media-keys]


### PR DESCRIPTION
It needs to be false as we do not want our users to be performing
downloads unexpectedly.

https://phabricator.endlessm.com/T13407