### PR TITLE
Disable automatic brightness adjustment

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -139,3 +139,6 @@ candidate-encodings=['UTF-8', 'GB18030', 'ISO-8859-15', 'UTF-16']
 
 [org.gnome.settings-daemon.plugins.media-keys]
 logout=''
+
+[org.gnome.settings-daemon.plugins.power]
+ambient-enabled=false


### PR DESCRIPTION
The ambient light detection does not work reliably at this time,
and on some laptops (e.g., the Lenovo Yoga 900) causes the
backlight to become significantly brighter whenever attempting
to watch a video with the brightness at a minimum.

https://phabricator.endlessm.com/T15607