### PR TITLE
Increase display settings change timeout up to 30 seconds

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -142,3 +142,7 @@ logout=''
 
 [org.gnome.settings-daemon.plugins.power]
 ambient-enabled=false
+
+# Increase display settings change timeout
+[org.gnome.mutter]
+display-configuration-timeout=30


### PR DESCRIPTION
Observing users going through the display settings change dialog, it
might be that the default timeout of 20 seconds is too short for
someone to read it and understand the question.

https://phabricator.endlessm.com/T16276