### PR TITLE
add endless-specific dconf user profile to /usr/share/dconf

### DIFF
--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -1,20 +1,38 @@
-do_subst = sed -e 's|@DATA_DIR[@]|$(datadir)|g'
+do_subst = sed \
+	-e 's|@DATA_DIR[@]|$(datadir)|g' \
+	-e 's|@LOCALSTATEDIR[@]|$(localstatedir)|g' \
+	$(NULL)
 
-50_eos-theme.gschema.override: com.endlessm.settings.gschema.override.in
-	$(AM_V_GEN) $(do_subst) $< > $@
+50_eos-theme.gschema.override: com.endlessm.settings.gschema.override.in Makefile
+	$(AM_V_GEN) $(do_subst) $< >$@.tmp && mv $@{.tmp,}
+
+user: user.in Makefile
+	$(AM_V_GEN) $(do_subst)  $< >$@.tmp && mv $@{.tmp,}
+
+dconf_profiledir = $(datadir)/dconf/profile
+dconf_profile_DATA = \
+	user \
+	$(NULL)
 
 settingsdir = $(datadir)/glib-2.0/schemas
 settings_DATA = \
-	50_eos-theme.gschema.override
+	50_eos-theme.gschema.override \
+	$(NULL)
 
 xsessiondir = $(sysconfdir)/X11/Xsession.d
-xsession_DATA = 65gtk-overlay-scrolling
+xsession_DATA = \
+	65gtk-overlay-scrolling \
+	$(NULL)
 
 EXTRA_DIST = \
 	com.endlessm.settings.gschema.override.in \
-	$(xsession_DATA)
+	user.in \
+	$(xsession_DATA) \
+	$(NULL)
 
 CLEANFILES = \
-	$(settings_DATA)
+	$(dconf_profile_DATA) \
+	$(settings_DATA) \
+	$(NULL)
 
 @GSETTINGS_RULES@

--- a/settings/user.in
+++ b/settings/user.in
@@ -1,0 +1,2 @@
+user-db:user
+file-db:@LOCALSTATEDIR@/lib/eos-image-defaults/settings


### PR DESCRIPTION
This should be merged together with changes to eos-image-builder
which stop the file being created in /etc/dconf and changes to
eos-boot-helper to remove the file from /etc on upgrade if it's
no longer needed.

https://phabricator.endlessm.com/T15704