### PR TITLE
settings: Enable geoclue location services by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -146,3 +146,7 @@ ambient-enabled=false
 # Increase display settings change timeout
 [org.gnome.mutter]
 display-configuration-timeout=30
+
+# Enable geoclue location services
+[org.gnome.system.location]
+enabled=true


### PR DESCRIPTION
settings: Enable geoclue location services by default