### PR TITLE
Specify the default lock screen image

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -41,6 +41,10 @@ button-layout=':minimize,maximize,close'
 [org.gnome.desktop.background]
 picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 
+# Specify the default lock screen image
+[org.gnome.desktop.screensaver]
+picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
+
 # Always enable log out
 [org.gnome.shell]
 always-show-log-out=true


### PR DESCRIPTION
Now that we expose this feature in Endless, let's set the default
lock screen to match the default desktop background.

https://phabricator.endlessm.com/T17243