### PR TITLE
settings: enable touchpad tap-to-click by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -154,3 +154,7 @@ display-configuration-timeout=30
 # Enable geoclue location services
 [org.gnome.system.location]
 enabled=true
+
+# Enable touchpad tap-to-click by default
+[org.gnome.desktop.peripherals.touchpad]
+tap-to-click=true


### PR DESCRIPTION
We found that many users were getting confused and thought
that the touchpad was broken.

https://phabricator.endlessm.com/T18022