### PR TITLE
Don't force a scaling factor, to automatically select that the right one

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -96,10 +96,6 @@ sidebar=false
 move-directories=true
 show-confirmation-dialog=false
 
-# Always turn off scaling factor, as we don't fully support it yet
-[org.gnome.desktop.interface]
-scaling-factor=1
-
 # Use Ctrl-Q as alternative to quit applications
 [org.gnome.desktop.wm.keybindings]
 close=['<Alt>F4', '<Ctrl>Q']


### PR DESCRIPTION
This was preventing HiDPI configurations from working, as a explicit scaling
factor of 1 would prevent the OS to automatically pick the right one.

https://phabricator.endlessm.com/T18349