### PR TITLE
Work around automake 1.15+ distcheck

### DIFF
--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,2 +1,5 @@
 icons/index.theme.in
+# Workaround intltool issue with automake 1.15+
+# https://bugs.launchpad.net/intltool/+bug/1117944
+sub/icons/index.theme.in
 icons/index.theme.in.in

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,4 +1,2 @@
-backgrounds/endlessos-backgrounds-default.xml.in
-backgrounds/endlessos-backgrounds-default.xml.in.in
 icons/index.theme.in
 icons/index.theme.in.in


### PR DESCRIPTION
Intltool can't deal with automake 1.15's decision to use a 2 level build directory for `distcheck`. Work around it like everyone else.

https://bugs.launchpad.net/intltool/+bug/1117944
https://phabricator.endlessm.com/T18349