### PR TITLE
settings: Hide the weekday in GnomeWallClock by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -24,6 +24,10 @@ icon-theme='EndlessOS'
 font-name='Lato 12'
 document-font-name='Lato Pro 12'
 
+# Hide the weekday by default
+[org.gnome.desktop.interface]
+clock-show-weekday=false
+
 [org.gnome.desktop.wm.preferences]
 titlebar-font='Lato Bold 13'
 titlebar-uses-system-font=false


### PR DESCRIPTION
https://phabricator.endlessm.com/T18781