### PR TITLE
Remove gnome autogen dep and add options to disable things

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,16 @@
-SUBDIRS = po icons settings fonts
+SUBDIRS = 
+
+if BUILD_ICONTHEME
+SUBDIRS += icons
+endif
+
+if BUILD_FONTS
+SUBDIRS += fonts
+endif
+
+if BUILD_SETTINGS
+SUBDIRS += settings
+endif
 
 MAINTAINERCLEANFILES =			\
 	Makefile.in			\

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = 
+SUBDIRS = po
 
 if BUILD_ICONTHEME
 SUBDIRS += icons

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,20 +1,2 @@
 #!/bin/sh
-# Run this to generate all the initial makefiles, etc.
-
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
-
-PKG_NAME="eos-themes"
-REQUIRED_AUTOMAKE_VERSION=1.9
-
-(test -f $srcdir/configure.ac) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
-}
-
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from the GNOME git"
-    exit 1
-}
-USE_GNOME2_MACROS=1 . gnome-autogen.sh
+libtoolize && intltoolize && aclocal && automake --add-missing && autoconf

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,26 @@
 #!/bin/sh
-libtoolize && intltoolize && aclocal && automake --add-missing && autoconf
+
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+
+olddir=`pwd`
+cd "$srcdir"
+
+INTLTOOLIZE=`which intltoolize`
+if test -z $INTLTOOLIZE; then
+        echo "*** Unable to find intltoolize; you must install intltool ***"
+        exit 1
+fi
+
+AUTORECONF=`which autoreconf`
+if test -z $AUTORECONF; then
+        echo "*** Unable to find autoreconf; you must install Autotools ***"
+        exit 1
+fi
+
+${INTLTOOLIZE} || exit $?
+${AUTORECONF} -f -v -i || exit $?
+
+cd "$olddir"
+
+test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,24 @@ fi
 # Workaround to make aclocal get the right flags
 AC_SUBST(ACLOCAL_AMFLAGS, "\${ACLOCAL_FLAGS}")
 
+AC_ARG_ENABLE(icontheme,
+              [AC_HELP_STRING([--enable-icontheme],
+                              [enable icon theme build [default=yes]])],,
+              [enable_icontheme="yes"])
+AM_CONDITIONAL([BUILD_ICONTHEME],[test "x$enable_icontheme" = "xyes"])
+
+AC_ARG_ENABLE(fonts,
+              [AC_HELP_STRING([--enable-fonts],
+                              [enable fonts build [default=yes]])],,
+              [enable_fonts="yes"])
+AM_CONDITIONAL([BUILD_FONTS],[test "x$enable_fonts" = "xyes"])
+
+AC_ARG_ENABLE(settings,
+              [AC_HELP_STRING([--enable-settings],
+                              [enable settings build [default=yes]])],,
+              [enable_settings="yes"])
+AM_CONDITIONAL([BUILD_SETTINGS],[test "x$enable_settings" = "xyes"])
+
 AC_CONFIG_FILES([
 Makefile
 fonts/Makefile


### PR DESCRIPTION
We need a way to only install the icon theme in order to create a flatpak extension

https://phabricator.endlessm.com/T18342