### PR TITLE
settings: Set first-run for GNOME Software as false

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -121,6 +121,7 @@ index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&
 [org.gnome.software]
 show-nonfree-ui=false
 enable-software-sources=false
+first-run=false
 show-folder-management=false
 show-nonfree-prompt=false
 show-nonfree-software=true


### PR DESCRIPTION
The reason is that this is only used for showing the welcome dialog at
the moment, and we've decided not to show this dialog as it's not very
useful.

https://phabricator.endlessm.com/T20235