### PR TITLE
add EndlessOS icon theme Flatpak extension to XDG_DATA_DIRS

### DIFF
--- a/debian/eos-icon-theme.conf.in
+++ b/debian/eos-icon-theme.conf.in
@@ -1,0 +1,6 @@
+D /run/share 0755 - - -
+D /run/share/icons 0755 - - -
+L /run/share/icons/EndlessOS - - - - /var/lib/flatpak/runtime/org.freedesktop.Platform.Icontheme.EndlessOS/@arch@/1.0/active/files
+D /run/share-extra 0755 - - -
+D /run/share-extra/icons 0755 - - -
+L /run/share-extra/icons/EndlessOS - - - - /var/endless-extra/flatpak/runtime/org.freedesktop.Platform.Icontheme.EndlessOS/@arch@/1.0/active/files

--- a/debian/eos-icon-theme.dirs
+++ b/debian/eos-icon-theme.dirs
@@ -1,0 +1,3 @@
+etc/X11/Xsession.d
+etc/profile.d
+lib/tmpfiles.d

--- a/debian/eos-icon-theme.install
+++ b/debian/eos-icon-theme.install
@@ -1,1 +1,3 @@
+debian/eos-icon-theme.sh etc/profile.d
+debian/eos-icon-theme.conf lib/tmpfiles.d
 usr/share/icons/EndlessOS

--- a/debian/eos-icon-theme.sh
+++ b/debian/eos-icon-theme.sh
@@ -1,0 +1,13 @@
+# /etc/profile.d/eos-icon-theme.sh
+# add Endless OS icon theme Flatpak extension to XDG_DATA_DIRS
+
+if [ "${XDG_DATA_DIRS#/run/share}" = "${XDG_DATA_DIRS}" ]; then
+    if [ -e /run/share-extra/icons/EndlessOS ]; then
+        XDG_DATA_DIRS="/run/share-extra/:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
+    fi
+    if [ -e /run/share/icons/EndlessOS ]; then
+        XDG_DATA_DIRS="/run/share/:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
+    fi
+fi
+
+export XDG_DATA_DIRS

--- a/debian/rules
+++ b/debian/rules
@@ -9,3 +9,13 @@ include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
 DEB_MAKE_INSTALL_TARGET  := install DESTDIR=$(CURDIR)/debian/tmp/
 DEB_DH_INSTALLGSETTINGS_ARGS_eos-default-settings += --priority=50
 DEB_CONFIGURE_EXTRA_FLAGS += --libdir=\$${prefix}/lib/$(DEB_HOST_MULTIARCH)
+
+install/eos-icon-theme::
+	sed "s/@arch@/$(DEB_HOST_GNU_CPU)/" \
+		< debian/eos-icon-theme.conf.in \
+		> debian/eos-icon-theme.conf
+	install -m644 debian/eos-icon-theme.sh \
+		debian/eos-icon-theme/etc/X11/Xsession.d/20eos-icon-theme
+
+clean::
+	rm -f debian/eos-icon-theme.conf


### PR DESCRIPTION
Use tmpfiles.d to set up folders in /run with symlinks to the EndlessOS
icon theme extension in /var/lib/flatpak and /var/endless-extra/flatpak.
Add profile.d and X11/Xsession.d fragments, similar to flatpak, which
adds the folders to XDG_DATA_DIRS if the icon theme exists (depending
on whether the system is "split" and has its flatpak installations in
/var/endless-extra).

https://phabricator.endlessm.com/T20599