### PR TITLE
Revert "settings: default to auto-suspend after 15 minutes"

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -146,15 +146,8 @@ candidate-encodings=['UTF-8', 'GB18030', 'ISO-8859-15', 'UTF-16']
 [org.gnome.settings-daemon.plugins.media-keys]
 logout=''
 
-# Disable automatic brightness adjustment, which does not work reliably.
-# Default to automatically suspend when idle for 15 minutes,
-# to comply with California Energy Commission (CEC) power regulations.
 [org.gnome.settings-daemon.plugins.power]
 ambient-enabled=false
-sleep-inactive-ac-timeout=900
-sleep-inactive-ac-type='suspend'
-sleep-inactive-battery-timeout=900
-sleep-inactive-battery-type='suspend'
 
 # Increase display settings change timeout
 [org.gnome.mutter]


### PR DESCRIPTION
This reverts commit bf77bbf7bd19bfa142be4bad76e1f4c8fc3db71e.

Upstream addressed this issue directly in gnome-settings-daemon,
so we'll go with their patch instead.

Note that the upstream solution went with 20 minutes rather than
15 minutes, matching the European standards (which exceeds the
CEC standard of 30 minutes).

https://phabricator.endlessm.com/T20634