### PR TITLE
settings: prioritize a few more apps in search results

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -106,7 +106,7 @@ close=['<Alt>F4', '<Ctrl>Q']
 
 # Override the order for default search providers
 [org.gnome.desktop.search-providers]
-sort-order=['com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop']
+sort-order=['org.gnome.Software.desktop', 'gnome-calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
 disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop', 'gnote.desktop']
 
 # Include Endless sample media in the directories indexed by tracker


### PR DESCRIPTION
Default order is now as follows:
- Internet (hard-coded in shell)
- Settings (hard-coded in shell)
- App Center (added via this commit)
- Calculator (added via this commit)
- Encyclopedias (previously prioritized in this gsetting)
- Weather (added via this commit)
- Help Center (added via this commit)
- All other apps (following any further logic in the shell)

https://phabricator.endlessm.com/T15929