### PR TITLE
settings: fix typo in gsettings schema

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -22,7 +22,7 @@ icon-theme='EndlessOS'
 # Specify the fonts and related settings
 [org.gnome.desktop.interface]
 font-name='Lato 12'
-document-font-name='Lato Pro 12'
+document-font-name='Lato 12'
 
 # Hide the weekday by default
 [org.gnome.desktop.interface]


### PR DESCRIPTION
document-font references non-existent "Lato Pro" font.

https://phabricator.endlessm.com/T20961