### PR TITLE
Tweak monospace font size

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -23,6 +23,7 @@ icon-theme='EndlessOS'
 [org.gnome.desktop.interface]
 font-name='Lato 12'
 document-font-name='Lato 12'
+monospace-font-name='Monospace 11.25'
 
 # Hide the weekday by default
 [org.gnome.desktop.interface]


### PR DESCRIPTION
After the upgrade from freetype 2.6 to 2.8, the default monospace
font size of 11 looks a bit squashed vertically.  Bumping this to 11.25
appears to exactly match the old behavior.

https://phabricator.endlessm.com/T20984