### PR TITLE
settings: Autorun the app associated with the x-content/ostree-software

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -86,9 +86,10 @@ monitor-library=true
 [org.gnome.shell]
 icon-grid-layout={}
 
-# Automatically play video DVDs
+# Automatically play video DVDs and launch the App Center when a USB with a repo
+# is inserted
 [org.gnome.desktop.media-handling]
-autorun-x-content-start-app=['x-content/unix-software', 'x-content/video-dvd']
+autorun-x-content-start-app=['x-content/ostree-software', 'x-content/unix-software', 'x-content/video-dvd']
 
 # Hide EOG sidebar by default
 [org.gnome.eog.ui]


### PR DESCRIPTION
This is used for opening the App Center when a USB with an ostree repo
is inserted.

https://phabricator.endlessm.com/T16950