### PR TITLE
settings: Do not override GNOME Software's first-run setting

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -120,7 +120,6 @@ index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&
 [org.gnome.software]
 show-nonfree-ui=false
 enable-software-sources=false
-first-run=false
 show-folder-management=false
 show-nonfree-prompt=false
 show-nonfree-software=true


### PR DESCRIPTION
This setting is used to display the first run dialog in GNOME Software
(i.e. the shopping bag), but this dialog has now been completely removed
downstream (T21725). So this setting doesn't need to be overridden
anymore.

GNOME Software still sets the first-run dialog to FALSE after its first
launch, so by removing this override, we gain the real information of
whether the program has been run before, which can be interesting in the
future if we decide to show a different first-run dialog.

https://phabricator.endlessm.com/T21725