### PR TITLE
settings: Remove the "download-updates" GNOME Software setting

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -123,7 +123,6 @@ enable-software-sources=false
 show-folder-management=false
 show-nonfree-prompt=false
 show-nonfree-software=true
-download-updates=true
 external-appstream-system-wide=true
 external-appstream-urls=['https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz']
 refresh-when-metered=true


### PR DESCRIPTION
This setting is now ignored in GNOME Software.

https://phabricator.endlessm.com/T22404