### PR TITLE
settings: set touchpad click-method=default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -148,6 +148,10 @@ ambient-enabled=false
 [org.gnome.system.location]
 enabled=true
 
-# Enable touchpad tap-to-click by default
+# Set "default" touchpad click method which allows libinput to use quirks to
+# decide between left/right click "areas" (the default) and "fingers"
+# (multi-touch two and three finger clicks for Apple/Chromebook/etc behaviour),
+# and enable tap-to-click by default
 [org.gnome.desktop.peripherals.touchpad]
+click-method=default
 tap-to-click=true


### PR DESCRIPTION
Upstream GNOME has gone to click-method=fingers and after trying for a month in
Endless, we have concluded this makes anyone with prior Windows or PC
experience conclude their touchpad is broken, and try to return their computer,
post on the forum, stop using Endless, fail OEM tests, etc. We think it's the
wrong call considering Endless is unlikely to enter the same channels /
geographies as Macs, Chromebooks or super high-end Ultrabooks.

https://phabricator.endlessm.com/T25142