### PR TITLE
WIP: Add Chrom[e|ium] policy file to enable SafeSearch

### DIFF
--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -32,6 +32,11 @@ xsession_DATA = \
 	65gtk-overlay-scrolling \
 	$(NULL)
 
+chrome_policydir = $(datadir)/eos-chrome-policies
+chrome_policy_DATA = \
+	safe_search.json \
+	$(NULL)
+
 EXTRA_DIST = \
 	dconf-defaults/settings \
 	com.endlessm.settings.gschema.override.in \

--- a/settings/safe_search.json
+++ b/settings/safe_search.json
@@ -1,0 +1,3 @@
+{
+  "ForceGoogleSafeSearch": true
+}


### PR DESCRIPTION
This path is not loaded by Chrome or Chromium by default, but we can (in
the image builder) symlink this file into the correct paths in /etc to
turn it on.

This is WIP because I'm not sure this is the right place for this file to live.

https://phabricator.endlessm.com/T25741