### PR TITLE
WIP: Add Chrom[e|ium] policy file to enable SafeSearch

### DIFF
--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -1,4 +1,5 @@
 etc/X11/Xsession.d
 usr/share/dconf
+usr/share/eos-chrome-policies
 usr/share/eos-default-settings
 usr/share/glib-2.0/schemas


### PR DESCRIPTION
This path is not loaded by Chrome or Chromium by default, but we can (in
the image builder) symlink this file into the correct paths in /etc to
turn it on.

This is WIP because I'm not sure this is the right place for this file to live. It's the counterpart to #312.

https://phabricator.endlessm.com/T25741