### PR TITLE
Add autogen.sh to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,10 @@ if BUILD_SETTINGS
 SUBDIRS += safe-defaults settings
 endif
 
+EXTRA_DIST = \
+	autogen.sh \
+	$(NULL)
+
 MAINTAINERCLEANFILES =			\
 	Makefile.in			\
 	aclocal.m4			\


### PR DESCRIPTION
For compatibility with deb-build-snapshot, which runs git clean -fdx on the
source tree, dh_autoreconf is configured to run autogen.sh so that the intltool
files are re-created. However, autogen.sh is not included in dist tarballs,
making builds fail on OBS. Ship it to square this circle.

https://phabricator.endlessm.com/T23464