### PR TITLE
settings: Show password hints

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -13,7 +13,7 @@ user-switch-enabled=false
 # Force the app menu to be on the application window rather than the shell panel
 # (required due to removal of the app menu from the panel)
 [org.gnome.settings-daemon.plugins.xsettings]
-overrides={"Gtk/ShellShowsAppMenu": <int32 0>}
+overrides={"Gtk/ShellShowsAppMenu": <int32 0>, "Gtk/EntryPasswordHintTimeout": <int32 600>}
 
 # Select the icon theme
 [org.gnome.desktop.interface]


### PR DESCRIPTION
We had this behaviour in gnome-initial-setup and concluded that it
helped users who were unaccustomed to typing passwords to make fewer
mistakes, and made it clearer when caps lock was engaged.

This enables the setting on all password entries in the OS.

https://phabricator.endlessm.com/T27358