### PR TITLE
settings: Update type for logout in media keys

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -134,7 +134,7 @@ show-browser=false
 candidate-encodings=['UTF-8', 'GB18030', 'ISO-8859-15', 'UTF-16']
 
 [org.gnome.settings-daemon.plugins.media-keys]
-logout=''
+logout=[]
 
 [org.gnome.settings-daemon.plugins.power]
 ambient-enabled=false


### PR DESCRIPTION
This fixes the following error when trying to install the new
gnome-settings-daemon 3.34.0:
  Error parsing key "logout" in schema "org.gnome.settings-daemon.plugins.media-keys"
  as specified in override file "/usr/share/glib-2.0/schemas/50_eos-theme.gschema.override":
  0-2:can not parse as value of type 'as'. Ignoring override for
  this key.

https://phabricator.endlessm.com/T27676