### PR TITLE
settings: Update type for logout in media keys

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -134,7 +134,7 @@ show-browser=false
 candidate-encodings=['UTF-8', 'GB18030', 'ISO-8859-15', 'UTF-16']
 
 [org.gnome.settings-daemon.plugins.media-keys]
-logout=''
+logout=[]
 
 [org.gnome.settings-daemon.plugins.power]
 ambient-enabled=false


### PR DESCRIPTION
Superseeds https://github.com/endlessm/eos-theme/pull/324 which had to be reverted while g-s-d is not integrated.

https://phabricator.endlessm.com/T27676