### PR TITLE
control: remove build-dep on libgtk2.0-bin

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,6 @@ Build-Depends: debhelper (>= 8),
                libglib2.0-bin,
                libglib2.0-dev,
                libgtk-3-bin,
-               libgtk2.0-bin,
                systemd
 Standards-Version: 3.9.3
 Homepage: http://www.endlessm.com


### PR DESCRIPTION
This has been unneeded since b5f3aec7ccf97b54ad030fb17af51317041933b1.

While not logically part of the changes on https://github.com/endlessm/eos-theme/pull/328, I noticed this at the same time.

https://phabricator.endlessm.com/T27255