### PR TITLE
settings: Add Endless-specific default taskbar icons

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -81,8 +81,10 @@ monitor-library=true
 
 # Default desktop layout. An empty value indicates that the real per-personality
 # default stored in usr/share/EndlessOS/personality-defaults/ should be used
+# Endless-specific default taskbar icons
 [org.gnome.shell]
 icon-grid-layout={}
+favorite-apps=['org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gnome.Nautilus.desktop']
 
 # Automatically play video DVDs and launch the App Center when a USB with a repo
 # is inserted


### PR DESCRIPTION
This used to be done in GNOME Shell itself, but it's
better to move this override to here.

https://phabricator.endlessm.com/T25835