### PR TITLE
settings: Update MIME type for ostree repos

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -89,7 +89,7 @@ favorite-apps=['org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gn
 # Automatically play video DVDs and launch the App Center when a USB with a repo
 # is inserted
 [org.gnome.desktop.media-handling]
-autorun-x-content-start-app=['x-content/ostree-software', 'x-content/unix-software', 'x-content/video-dvd']
+autorun-x-content-start-app=['x-content/ostree-repository', 'x-content/unix-software', 'x-content/video-dvd']
 
 # Hide EOG sidebar by default
 [org.gnome.eog.ui]


### PR DESCRIPTION
This MIME type was renamed in the process of being upstreamed; see
https://gitlab.freedesktop.org/xdg/shared-mime-info/merge_requests/22

Update it here so that upon insertion of USB drives containing OS/App
updates, GNOME Software will be automatically opened and the USB
category will be properly populated with apps.

https://phabricator.endlessm.com/T23512