### PR TITLE
overrides: Get facesdirs setting from gsettings-desktop-schemas

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -27,6 +27,7 @@ document-font-name='Lato 12'
 # Hide the weekday by default
 [org.gnome.desktop.interface]
 clock-show-weekday=false
+facesdirs=['/usr/share/pixmaps/faces/EndlessOS/']
 
 [org.gnome.desktop.wm.preferences]
 titlebar-font='Lato Bold 13'
@@ -152,6 +153,3 @@ enabled=true
 [org.gnome.desktop.peripherals.touchpad]
 click-method='default'
 tap-to-click=true
-
-[org.gnome.ControlCenter]
-facesdirs=['/usr/share/pixmaps/faces/EndlessOS/']


### PR DESCRIPTION
We are moving this setting to gsettings-desktop-schemas so that
gnome-initial-setup can use it without a hard dependency on
gnome-control-center.

Squash with 73e0f7d8abe6c7011d685e1200a52edeaeaee03e on the next rebase.

https://phabricator.endlessm.com/T28364