### PR TITLE
build: Add option to disable faces installation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdunitdir='$${prefix}/lib/systemd/system' \
 	$(NULL)
 
-SUBDIRS = po faces
+SUBDIRS = po
 
 if BUILD_ICONTHEME
 SUBDIRS += icons
@@ -15,6 +15,10 @@ endif
 
 if BUILD_SETTINGS
 SUBDIRS += safe-defaults settings
+endif
+
+if BUILD_FACES
+SUBDIRS += faces
 endif
 
 EXTRA_DIST = \

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,12 @@ AC_ARG_ENABLE(settings,
               [enable_settings="yes"])
 AM_CONDITIONAL([BUILD_SETTINGS],[test "x$enable_settings" = "xyes"])
 
+AC_ARG_ENABLE([faces],
+              [AC_HELP_STRING([--enable-faces],
+                              [enable faces build [default=yes]])],,
+              [enable_faces="yes"])
+AM_CONDITIONAL([BUILD_FACES],[test "x$enable_faces" = "xyes"])
+
 # allow systemdunitdir to be overridden on the command line so
 # that make distcheck doesn't fail when run as a non-root user
 m4_define([no_systemdunitdir_error],


### PR DESCRIPTION
Building eos-theme for the org.freedesktop.Platform.Icontheme.EndlessOS
flatpak runtime fails because /usr/share/runtime/share/pixmaps is
read-only.

Allow disabling installation of the faces icons. They're only relevant
for the host OS and need not be part of an icon theme runtime.

https://phabricator.endlessm.com/T28493