### PR TITLE
overrides: disable touchscreen autorotation

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -142,6 +142,9 @@ logout=[]
 [org.gnome.settings-daemon.plugins.power]
 ambient-enabled=false
 
+[org.gnome.settings-daemon.peripherals.touchscreen]
+orientation-lock=true
+
 # Enable geoclue location services
 [org.gnome.system.location]
 enabled=true


### PR DESCRIPTION
We have found in practice that the physical orientation of the
accelerometer within the computer hardware is often incorrectly
detected. While we have been able to improve some cases by adding
hardware-specific special cases, this issue still bites users from time
to time, and it is rather hard to recover from – you need to rotate the
laptop to an awkward angle (to convince it to rotate the screen to the
normal landscape orientation) then either click a menu item or press
Win+O, neither of which is easy to do one-handed.

Since we do not specifically aim to support tablets (or convertibles in
tablet mode), disable automatic rotation by default. Brave users can
always enable it using the menu item.

See
https://lists.freedesktop.org/archives/systemd-devel/2019-September/043404.html
and resulting thread for some background. In
https://lists.freedesktop.org/archives/systemd-devel/2019-September/043409.html
Bastien Nocera proposed disabling autorotation by default (though typoed
as "false" rather than "true").

https://phabricator.endlessm.com/T28520