### PR TITLE
settings: re-enable Nautilus search provider by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -97,7 +97,7 @@ show-confirmation-dialog=false
 # Override the order for default search providers
 [org.gnome.desktop.search-providers]
 sort-order=['org.gnome.Software.desktop', 'org.gnome.Calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
-disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop']
+disabled=['org.gnome.clocks.desktop']
 
 # Include Endless sample media in the directories indexed by tracker
 # (tracker does not follow symlinks, so we need the absolute path

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -105,7 +105,7 @@ show-confirmation-dialog=false
 # Override the order for default search providers
 [org.gnome.desktop.search-providers]
 sort-order=['org.gnome.Software.desktop', 'gnome-calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
-disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop', 'gnote.desktop']
+disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop']
 
 # Include Endless sample media in the directories indexed by tracker
 # (tracker does not follow symlinks, so we need the absolute path

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -104,7 +104,7 @@ show-confirmation-dialog=false
 
 # Override the order for default search providers
 [org.gnome.desktop.search-providers]
-sort-order=['org.gnome.Software.desktop', 'gnome-calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
+sort-order=['org.gnome.Software.desktop', 'org.gnome.Calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
 disabled=['org.gnome.Nautilus.desktop', 'org.gnome.clocks.desktop']
 
 # Include Endless sample media in the directories indexed by tracker

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -56,10 +56,6 @@ always-show-log-out=true
 [org.gnome.nautilus.preferences]
 default-folder-viewer='list-view'
 
-# Do not restore browser previous session
-[com.endlessm.eos-browser]
-restore-session-policy='never'
-
 # Decrease the likelihood that an unsteady click is interpreted as a drag
 [org.gnome.settings-daemon.peripherals.mouse]
 drag-threshold=10
@@ -67,10 +63,6 @@ drag-threshold=10
 # Disable the switch user option on the user menu
 [org.gnome.desktop.lockdown]
 disable-user-switching=true
-
-# Set Exploration Center as browser homepage
-[com.endlessm.eos-browser]
-homepage-url='file:///usr/share/EndlessOS/exploration_center/index.html'
 
 # Automatically import user's pictures into Shotwell
 [org.yorba.shotwell.preferences.files]


### PR DESCRIPTION
This was disabled by default in 2a21c39dc2a7598c589337c603049eb85281e248.
The rationale given was:

> We want our global search to feel more like google where you search
> for things like "Mexico", "rabbit" and what not, and less like a
> traditional system search where you look for "my-list.txt".

I think I understand the sentiment here, but I think the cost (making it 
harder to discover your files) is too high. The lack of local file search
was reported as a bug/feature request by two people within Endless, and I
think that as our target audience has moved further from
“inexperienced, mostly-offline computer user” the need for this feature has
increased somewhat.

Remove it from the 'disabled' list, but leave it naturally sorted within 
the other search provides not listed in the sort-order. Users can reorder
or disable search providers in Settings, but it's easier to disable a
feature you don't like than it is to enable a feature you didn't know you
had.

I also took this opportunity to fix and clean up some stale overrides in
this file.

https://phabricator.endlessm.com/T28224