### PR TITLE
Add default dconf value for shell's enabled-extensions and lock them

### DIFF
--- a/settings/dconf-defaults/locks/00_settings
+++ b/settings/dconf-defaults/locks/00_settings
@@ -1,0 +1,11 @@
+# This file specifies gsettings keys which are immutable.
+# https://help.gnome.org/admin/system-admin-guide/stable/dconf-lockdown.html.en
+
+# Endless OS users should not be able to enable or disable system extensions.
+# This also have the side-effect that users won't be able to run their own extensions,
+# but we are still going on with that decision.
+# https://phabricator.endlessm.com/T28777
+/org/gnome/shell/enabled-extensions
+/org/gnome/shell/development-tools
+/org/gnome/shell/disabled-extensions
+/org/gnome/shell/disable-user-extensions

--- a/settings/dconf-defaults/settings
+++ b/settings/dconf-defaults/settings
@@ -21,3 +21,6 @@ show-in-lock-screen=false
 # https://phabricator.endlessm.com/T28777
 [org/gnome/shell]
 enabled-extensions=['ubuntu-appindicators@ubuntu.com']
+development-tools=false
+disabled-extensions=['']
+disable-user-extensions=true

--- a/settings/dconf-defaults/settings
+++ b/settings/dconf-defaults/settings
@@ -15,3 +15,9 @@
 # https://phabricator.endlessm.com/T20990
 [org/gnome/desktop/notifications/application/gnome-power-panel]
 show-in-lock-screen=false
+
+# Preset the enabled-extensions gsetting to enable mandatory shell extensions on Endless OS.
+# https://help.gnome.org/admin/system-admin-guide/stable/extensions-lockdown.html.en
+# https://phabricator.endlessm.com/T28777
+[org/gnome/shell]
+enabled-extensions=['ubuntu-appindicators@ubuntu.com']


### PR DESCRIPTION
This introduces a new directory `settings/dconf-defaults/locks` which is responsible for locking the dconf keys. I didn't find any new changes to the makefiles as essentially `dconf compile` takes a entire directory to compile the key-files into the binary-database. I assume the `settings/dconf-defaults/locks`  will also get respected while compilation (Tested locally :heavy_check_mark: )
_________

CC @GeorgesStavracas 


https://phabricator.endlessm.com/T28777
