### PR TITLE
settings: Remove outdated override for gnome-software

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -110,7 +110,6 @@ index-recursive-directories=['&DESKTOP', '&DOCUMENTS', '&DOWNLOAD', '&MUSIC', '&
 [org.gnome.software]
 show-nonfree-ui=false
 enable-repos-dialog=false
-show-folder-management=false
 show-nonfree-prompt=false
 external-appstream-system-wide=true
 external-appstream-urls=['https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz']


### PR DESCRIPTION
The `show-folder-management` setting was removed in gnome-software
commit 67a5bff938dad for 3.36.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28771