### PR TITLE
autostart: Add autostart desktop file to set EKN flatpak permissions

### DIFF
--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -32,6 +32,11 @@ xsession_DATA = \
 	65gtk-overlay-scrolling \
 	$(NULL)
 
+autostartdir = $(datadir)/gnome/autostart
+dist_autostart_DATA = \
+	com.endlessm.EknServicesMultiplexer-flatpak-permissions.desktop \
+	$(NULL)
+
 EXTRA_DIST = \
 	dconf-defaults/settings \
 	com.endlessm.settings.gschema.override.in \

--- a/settings/com.endlessm.EknServicesMultiplexer-flatpak-permissions.desktop
+++ b/settings/com.endlessm.EknServicesMultiplexer-flatpak-permissions.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=EKN Multiplexer Permissions
+Comment=Sets the default flatpak permissions for the EKN Multiplexer
+# FIXME: Workaround for the lack of system-level defaults for flatpak permissions
+# See https://github.com/flatpak/xdg-desktop-portal/issues/471
+# and https://phabricator.endlessm.com/T29677
+Exec=/usr/bin/sh -c "export FLATPAK_FANCY_OUTPUT=0; if ! flatpak permission-list background background | grep -q '[[:space:]]com.endlessm.EknServicesMultiplexer[[:space:]]'; then flatpak permission-set background background com.endlessm.EknServicesMultiplexer yes || true; fi"
+OnlyShowIn=GNOME;
+X-GNOME-Autostart-Phase=Application


### PR DESCRIPTION
Flatpak (correctly) warns the user about EKN multiplexer continuing to
run as a background process. As the multiplexer is designed to do that,
set the permissions in the xdg-desktop-portal database so that the
multiplexer is allowed to run in the background, and the user isn’t
notified about it.

It has to be done on startup so all users have the permissions set in
their session (xdg-desktop-portal provides no system-wide configuration
hook), and it can’t be done from within Hack as that would require
breaking the flatpak sandboxing.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29677