### PR TITLE
eos-default-settings: Install autostart file for flatpak permissions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+eos-theme (1.1.6) master; urgency=medium
+
+  * Install an autostart desktop file to set the flatpak permissions for the
+    EKN multiplexer (https://phabricator.endlessm.com/T29677)
+
+ -- Philip Withnall <withnall@endlessm.com>  Wed, 15 Apr 2020 11:28:00 +0100
+
 eos-theme (1.1.5~dev2) unstable; urgency=low
 
   * Install dconf defaults for OSTree in /usr/share/eos-image-defaults

--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -5,3 +5,4 @@ usr/share/dconf
 usr/share/eos-default-settings
 usr/share/eos-safe-defaults
 usr/share/glib-2.0/schemas
+usr/share/gnome/autostart


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T29677