### PR TITLE
safe-defaults: correct Chromium config path to /etc/chromium-browser

### DIFF
--- a/safe-defaults/tmpfiles-disable.conf.in
+++ b/safe-defaults/tmpfiles-disable.conf.in
@@ -1,3 +1,9 @@
 r @SYSCONFDIR@/NetworkManager/conf.d/opendns-family-shield.conf
-r @SYSCONFDIR@/chromium/policies/managed/safe-search.json
+r @SYSCONFDIR@/chromium-browser/policies/managed/safe-search.json
 r @SYSCONFDIR@/opt/chrome/policies/managed/safe-search.json
+
+# cleanup fallout from T29779
+r @SYSCONFDIR@/chromium/policies/managed/safe-search.json
+r @SYSCONFDIR@/chromium/policies/managed
+r @SYSCONFDIR@/chromium/policies
+r @SYSCONFDIR@/chromium

--- a/safe-defaults/tmpfiles-enable.conf.in
+++ b/safe-defaults/tmpfiles-enable.conf.in
@@ -7,5 +7,11 @@
 # be made empty rather than deleted, otherwise the change from L to r
 # in this file will be ineffective.
 L @SYSCONFDIR@/NetworkManager/conf.d/opendns-family-shield.conf - - - - @DATAROOTDIR@/eos-safe-defaults/nm-opendns-family-shield.conf
-L @SYSCONFDIR@/chromium/policies/managed/safe-search.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome-safe-search.json
+L @SYSCONFDIR@/chromium-browser/policies/managed/safe-search.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome-safe-search.json
 L @SYSCONFDIR@/opt/chrome/policies/managed/safe-search.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome-safe-search.json
+
+# cleanup fallout from T29779
+r @SYSCONFDIR@/chromium/policies/managed/safe-search.json
+r @SYSCONFDIR@/chromium/policies/managed
+r @SYSCONFDIR@/chromium/policies
+r @SYSCONFDIR@/chromium


### PR DESCRIPTION
This was previously only tested with Chrome and so nobody noticed we
had the Chromium config path wrong. We use /etc/chromium-browser so
change any mention of /etc/chromium to this, and remove any noise that
we may have created.

https://phabricator.endlessm.com/T29779