### PR TITLE
settings: use CNAME for external appstream URL

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -112,7 +112,7 @@ show-nonfree-ui=false
 enable-repos-dialog=false
 show-nonfree-prompt=false
 external-appstream-system-wide=true
-external-appstream-urls=['https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz']
+external-appstream-urls=['https://gnome-software-data.endlessm.com/app-info/eos-extra.xml.gz']
 screenshot-cache-age-maximum=0
 
 # Remove default screencast duration limit


### PR DESCRIPTION
Somewhat weird behaviour where I got the update from https://github.com/endlessm/gnome-software-data/pull/20 when I fetched from https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz, then got a stale copy from https://gnome-software-data.endlessm.com/app-info/eos-extra.xml.gz, then got the stale version from the cloudfront URL. But presumably this is just standard CDN latency stuff.

https://phabricator.endlessm.com/T28855