### PR TITLE
settings: Enable Kolibri search provider by default

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -98,6 +98,7 @@ show-confirmation-dialog=false
 [org.gnome.desktop.search-providers]
 sort-order=['org.gnome.Software.desktop', 'org.gnome.Calculator.desktop', 'com.endlessm.encyclopedia.ar.desktop', 'com.endlessm.encyclopedia.en.desktop', 'com.endlessm.encyclopedia.es.desktop', 'com.endlessm.encyclopedia.fr.desktop', 'com.endlessm.encyclopedia.id.desktop', 'com.endlessm.encyclopedia.pt.desktop', 'com.endlessm.encyclopedia.th.desktop', 'com.endlessm.encyclopedia.vi.desktop', 'org.gnome.Weather.desktop', 'org.gnome.Yelp.desktop']
 disabled=['org.gnome.clocks.desktop']
+enabled=['org.learningequality.Kolibri.desktop']
 
 # Include Endless sample media in the directories indexed by tracker
 # (tracker does not follow symlinks, so we need the absolute path


### PR DESCRIPTION
Flatpak rewrites apps' search providers to be disabled by default, to
avoid users' desktop searches unwittingly being sent to apps. (Users are
unlikely to expect that installing an app allows it to read all their
searches.)

We trust Learning Equality; so, enable Kolibri's search provider by
default.

This change will only take effect for users who have not manually
enabled any search providers in the past, since it is only a default
value for the key.

https://phabricator.endlessm.com/T28681