### PR TITLE
control: Add build depencency on librsvg2-common

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends: debhelper (>= 8),
                libglib2.0-bin,
                libglib2.0-dev,
                libgtk-3-bin,
+               librsvg2-common,
                systemd
 Standards-Version: 3.9.3
 Homepage: http://www.endlessm.com


### PR DESCRIPTION
This is needed to ensure the SVG pixbuf loader is installed. Without it,
gtk-encode-symbolic-svg fails to load the source SVG icons. Possibly
libgtk-3-bin should have a harder dependency on librsvg2-common.
Apparently this was pulled in implicitly before by adwaita-icon-theme,
but that's no longer the case.

https://phabricator.endlessm.com/T30533