### PR TITLE
Re-enable switch user option on user menu and lock screen

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -6,10 +6,6 @@ dynamic-workspaces=false
 [org.gnome.desktop.wm.preferences]
 num-workspaces=1
 
-# Disable switching users from the lock screen
-[org.gnome.desktop.screensaver]
-user-switch-enabled=false
-
 # Force the app menu to be on the application window rather than the shell panel
 # (required due to removal of the app menu from the panel)
 [org.gnome.settings-daemon.plugins.xsettings]
@@ -59,10 +55,6 @@ default-folder-viewer='list-view'
 # Decrease the likelihood that an unsteady click is interpreted as a drag
 [org.gnome.settings-daemon.peripherals.mouse]
 drag-threshold=10
-
-# Disable the switch user option on the user menu
-[org.gnome.desktop.lockdown]
-disable-user-switching=true
 
 # Automatically import user's pictures into Shotwell
 [org.yorba.shotwell.preferences.files]


### PR DESCRIPTION
This reverts f0148f0f09e113f6ef6862d6894d035122bd41af and
fe2a78d8bc80a13b85dad4183f2b1a7bf53ec760.

In the intervening 7 years, several things have changed:

- We are no longer attempting to run with 1 GB of RAM.
- We have discontinued updates for EC-100.
- We have re-enabled user display server, and GDM's greeter session
  self-destructs when not in use.

On multi-user systems, with these features disabled if one user puts
the computer to sleep without logging out, then the computer cannot be
used by another user without forcibly power-cycling the computer. This
has been reported as an issue by at least one deployment, as well as
several individuals within Endless.

https://phabricator.endlessm.com/T14074
