### PR TITLE
eos-default-settings: Ship default container registries configuration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Replaces: eos-theme (<< 1.4.0)
 Breaks: eos-theme (<< 1.4.0)
 Description: default settings for EndlessOS
  This package contains default settings for EndlessOS, including
- GSettings overrides and X11 environment defaults.
+ GSettings overrides and X11 environment defaults, among others.
 
 Package: eos-extra-faces
 Architecture: any

--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -1,4 +1,5 @@
 lib/systemd/system
+etc/containers/registries.conf.d
 etc/X11/Xsession.d
 usr/sbin/eos-safe-defaults
 usr/share/dconf


### PR DESCRIPTION
Source changes at https://github.com/endlessm/eos-theme/pull/354.

https://phabricator.endlessm.com/T31300