### PR TITLE
icons: Fix icon theme name/comment

### DIFF
--- a/icons/index.theme.in
+++ b/icons/index.theme.in
@@ -1,6 +1,6 @@
 [Icon Theme]
-_Name=EndlessOS
-_Comment=EndlessOS icon theme
+Name=EndlessOS
+Comment=EndlessOS icon theme
 Inherits=Adwaita
 
 # Directory list


### PR DESCRIPTION
This fixes the following warning:
``` 
  (org.gnome.Nautilus:17236): Gtk-WARNING **: 10:06:44.268: Theme file for EndlessOS has no name
``` 

Regression from commit 2763837b3ecab604085f8375eba8490cfed42f10.

https://phabricator.endlessm.com/T31501