### PR TITLE
Install new polkit rule to permit user admin printers

### DIFF
--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -42,12 +42,18 @@ containers_settings_DATA = \
 	00-default-registries.conf \
 	$(NULL)
 
+cupspkhelperdir = $(datadir)/polkit-1/rules.d
+cupspkhelper_DATA = \
+	com.endlessm.Config.Printing.rules \
+	$(NULL)
+
 EXTRA_DIST = \
 	dconf-defaults/settings \
 	com.endlessm.settings.gschema.override.in \
 	user.in \
 	$(xsession_DATA) \
 	$(containers_settings_DATA) \
+	$(cupspkhelper_DATA) \
 	$(NULL)
 
 CLEANFILES = \

--- a/settings/com.endlessm.Config.Printing.rules
+++ b/settings/com.endlessm.Config.Printing.rules
@@ -1,0 +1,9 @@
+polkit.addRule(function(action, subject) {
+    /* Permit users in group lpadmin to admin printers via GUI */
+    if (action.id.indexOf("org.opensuse.cupspkhelper.mechanism.") &&
+        subject.active && subject.local && subject.isInGroup("lpadmin")) {
+            return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+});


### PR DESCRIPTION
Install com.endlessm.Config.Printing.rules into
/usr/share/polkit-1/rules.d/. That permits users in group lpadmin to
admin printers via GUI.

https://phabricator.endlessm.com/T30973