### PR TITLE
eos-default-settings: Install new polkit rule to permit user admin printers

### DIFF
--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -7,3 +7,4 @@ usr/share/eos-default-settings
 usr/share/eos-safe-defaults
 usr/share/glib-2.0/schemas
 usr/share/gnome/autostart
+usr/share/polkit-1/rules.d


### PR DESCRIPTION
Install com.endlessm.Config.Printing.rules into
/usr/share/polkit-1/rules.d/.

https://phabricator.endlessm.com/T30973