### PR TITLE
eos-default-settings: Fix cupspkhelper's action ID match condition

### DIFF
--- a/settings/com.endlessm.Config.Printing.rules
+++ b/settings/com.endlessm.Config.Printing.rules
@@ -1,6 +1,6 @@
 polkit.addRule(function(action, subject) {
     /* Permit users in group lpadmin to admin printers via GUI */
-    if (action.id.indexOf("org.opensuse.cupspkhelper.mechanism.") &&
+    if (action.id.indexOf("org.opensuse.cupspkhelper.mechanism.") == 0 &&
         subject.active && subject.local && subject.isInGroup("lpadmin")) {
             return polkit.Result.YES;
     }


### PR DESCRIPTION
Fix the action ID "org.opensuse.cupspkhelper.mechanism." match
condition.

https://phabricator.endlessm.com/T30973