### PR TITLE
settings: Add NetworkManager connectivity check config

### DIFF
--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -47,6 +47,11 @@ cupspkhelper_DATA = \
 	com.endlessm.Config.Printing.rules \
 	$(NULL)
 
+nmconfdir = $(exec_prefix)/lib/NetworkManager/conf.d
+dist_nmconf_DATA = \
+	endless-connectivity.conf \
+	$(NULL)
+
 EXTRA_DIST = \
 	dconf-defaults/settings \
 	com.endlessm.settings.gschema.override.in \

--- a/settings/endless-connectivity.conf
+++ b/settings/endless-connectivity.conf
@@ -1,0 +1,4 @@
+[connectivity]
+uri=http://status.endlessm.com/network_status_check.txt
+response=NetworkManager is online
+interval=300


### PR DESCRIPTION
Previously we shipped this directly in
`/etc/NetworkManager/NetworkManager.conf`, but no we're using Debian's
package without downstream modifications. Now it can live here with the
bonus of putting it in `/usr` where it won't be modified.

https://phabricator.endlessm.com/T32335