### PR TITLE
eos-default-settings: Install NetworkManager conf files

### DIFF
--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -1,6 +1,7 @@
 lib/systemd/system
 etc/containers/registries.conf.d
 etc/X11/Xsession.d
+usr/lib/NetworkManager/conf.d
 usr/sbin/eos-safe-defaults
 usr/share/dconf
 usr/share/eos-default-settings


### PR DESCRIPTION
Add the OS NetworkManager conf.d directory. Currently this provides
connectivity check settings for Endless.

https://phabricator.endlessm.com/T32335