### PR TITLE
safe-defaults: Correctly start service after OS update

### DIFF
--- a/safe-defaults/eos-safe-defaults.service.in
+++ b/safe-defaults/eos-safe-defaults.service.in
@@ -1,7 +1,11 @@
 [Unit]
 Description=Enable/update the Endless family-safe default settings
 ConditionNeedsUpdate=/etc
-Before=NetworkManager.service
+DefaultDependencies=no
+Requires=local-fs.target
+After=local-fs.target
+Before=NetworkManager.service systemd-update-done.service
+Conflicts=shutdown.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This unit is intended to be run after an OS update, in case the set of
symlinks to install has changed as part of the update. (This was the
case in 4.0.1, and in particular involves deleting a symlink in the
NetworkManager configuration that points to a now-deleted file on disk.)

Unfortunately, the unit was not correctly configured to run before
systemd-update-done.service. This means that ConditionNeedsUpdate=/etc
will never be true when systemd considers activating the unit, so it did
not get run by the OS update. As a result, NetworkManager fails to start
and the computer cannot connect to the internet any more.

Fix this by cargo-culting the relevant systemd dependencies. The key
point is to disable default dependencies, then order this service
between the filesystem becoming available and after systemd creating the
/etc/.updated stamp file that controls ConditionNeedsUpdate.

https://phabricator.endlessm.com/T32828
