### PR TITLE
safe-defaults: DoH: set DnsOverHttpsMode as automatic mode

### DIFF
--- a/safe-defaults/dns-over-https.json
+++ b/safe-defaults/dns-over-https.json
@@ -1,4 +1,4 @@
 {
-  "DnsOverHttpsMode": "secure",
+  "DnsOverHttpsMode": "automatic",
   "DnsOverHttpsTemplates": "https://doh.familyshield.opendns.com/dns-query"
 }


### PR DESCRIPTION
Set DnsOverHttpsMode as automatic mode for those types which cannot be
parsed by DNS-over-HTTPS mechanism in Chrome/Chromium.

The "automatic" mode will send DNS-over-HTTPS queries first if a
DNS-over-HTTPS server is available and may fallback to sending insecure
queries on error. [1]

[1]: https://chromeenterprise.google/policies/#DnsOverHttpsMode

https://phabricator.endlessm.com/T32832