### PR TITLE
safe-defaults: Manage safe defaults' state by systemd

### DIFF
--- a/safe-defaults/eos-safe-defaults.service.in
+++ b/safe-defaults/eos-safe-defaults.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=Enable/update the Endless family-safe default settings
-ConditionNeedsUpdate=/etc
 DefaultDependencies=no
 Requires=local-fs.target
 After=local-fs.target
@@ -11,6 +10,7 @@ Conflicts=shutdown.target
 Type=oneshot
 RemainAfterExit=true
 ExecStart=@SBINDIR@/eos-safe-defaults enable
+ExecStop=@SBINDIR@/eos-safe-defaults disable
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The original eos-safe-defaults.service will be guarded by "/etc"'s
needing update condition, which leads the service start failed at next
and following boots. Then, Chromium's safe search configration files
will not be linked to Chromium flatpak Policy path which is under
"/run". Because, "/run" is a tmpfs that means safe defaults having no
effect for Chromium after a reboot.

This patch removes the condition check to ensure
eos-safe-defaults.service can start correctly everytime. Also, adds the
stop command to disable safe defaults by systemd control.

https://phabricator.endlessm.com/T32833