### PR TITLE
settings: Re-enable dynamic workspaces (+2)

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -47,11 +47,7 @@ drag-threshold=10
 [org.yorba.shotwell.preferences.files]
 auto-import=true
 
-# Default desktop layout. An empty value indicates that the real per-personality
-# default stored in usr/share/EndlessOS/personality-defaults/ should be used
-# Endless-specific default taskbar icons
 [org.gnome.shell]
-icon-grid-layout={}
 favorite-apps=['org.gnome.Software.desktop', 'com.hack_computer.Clubhouse.desktop', 'org.chromium.Chromium.desktop', 'org.gnome.Nautilus.desktop']
 
 # Automatically play video DVDs and launch the App Center when a USB with a repo

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -1,11 +1,3 @@
-# Disable dynamic workspaces and set default number of workspaces to 1
-# (required for the current solution to keeping the desktop always active)
-[org.gnome.shell.overrides]
-dynamic-workspaces=false
-
-[org.gnome.desktop.wm.preferences]
-num-workspaces=1
-
 # Force the app menu to be on the application window rather than the shell panel
 # (required due to removal of the app menu from the panel)
 [org.gnome.settings-daemon.plugins.xsettings]

--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -1,8 +1,3 @@
-# Force the app menu to be on the application window rather than the shell panel
-# (required due to removal of the app menu from the panel)
-[org.gnome.settings-daemon.plugins.xsettings]
-overrides={"Gtk/ShellShowsAppMenu": <int32 0>}
-
 # Select the icon theme
 [org.gnome.desktop.interface]
 icon-theme='EndlessOS'


### PR DESCRIPTION
Previously we disabled workspaces by:

1. Disabling dynamic workspaces
2. Setting the number of workspaces to '1'

The improved workspace UI was one of the key things validated by the
user research that led up to GNOME 40, and our desktop is now better
aligned with this. Re-enable GNOME's default dynamic workspaces
behaviour.

(GNOME Settings 41 introduced user-facing controls for these settings
anyway.)

I also noticed a couple of other obsolete settings overrides, which this PR removes.

https://phabricator.endlessm.com/T33334