### PR TITLE
settings: Don't autostart OSTree repos on removable storage

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -50,10 +50,10 @@ auto-import=true
 [org.gnome.shell]
 favorite-apps=['org.gnome.Software.desktop', 'com.hack_computer.Clubhouse.desktop', 'org.chromium.Chromium.desktop', 'org.gnome.Nautilus.desktop']
 
-# Automatically play video DVDs and launch the App Center when a USB with a repo
-# is inserted
+# Automatically play video DVDs; don't autostart for
+# x-content/ostree-repository since Software doesn't currently support it.
 [org.gnome.desktop.media-handling]
-autorun-x-content-start-app=['x-content/ostree-repository', 'x-content/unix-software', 'x-content/video-dvd']
+autorun-x-content-start-app=['x-content/unix-software', 'x-content/video-dvd']
 
 # Hide EOG sidebar by default
 [org.gnome.eog.ui]


### PR DESCRIPTION
x-content/ostree-repository is the type of removable devices which
contain a non-empty directory at the root named .ostree, ostree/repo or
var/lib/flatpak/repo.

In Endless OS 4 and earlier, GNOME Software could install apps and OS
updates from such drives, as a downstream change. This support was
removed to ease the rebase to GNOME Software 41, in hopes of restoring
it upstream later. As a result, inserting a USB drive with such a
directory would cause Software to start and display the following error:

> Failed to install file: not supported

Remove this mime type from the list to autostart.

For reference, the upstream value is:

    [ 'x-content/unix-software', 'x-content/ostree-repository' ]

x-content/unix-software is to support the [Desktop Application Autostart
Spec][0] and is handled by Nautilus.

[0]: https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html#mounting

https://phabricator.endlessm.com/T33492
