### PR TITLE
settings: Drop show-nonfree-prompt GSettings key for gnome-software

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -76,7 +76,6 @@ enabled=['org.learningequality.Kolibri.desktop']
 [org.gnome.software]
 show-nonfree-ui=false
 enable-repos-dialog=false
-show-nonfree-prompt=false
 external-appstream-system-wide=true
 external-appstream-urls=['https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz']
 screenshot-cache-age-maximum=0


### PR DESCRIPTION
It was removed upstream in commit a695e19504dcf in 2021.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

https://phabricator.endlessm.com/T33424