### PR TITLE
Remove font hinting override

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -16,9 +16,6 @@ avatar-directories=['/usr/share/pixmaps/faces/EndlessOS/']
 titlebar-font='Lato Bold 13'
 titlebar-uses-system-font=false
 
-[org.gnome.settings-daemon.plugins.xsettings]
-hinting='slight'
-
 # Enable the minimize and maximize buttons
 [org.gnome.desktop.wm.preferences]
 button-layout='appmenu:minimize,maximize,close'


### PR DESCRIPTION
This setting was moved in GNOME 40.
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/8c4bca1d2d1a641ccb1a8111b1bc90806d7c144e

'slight' has been the default in GNOME since 2015
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/commit/e2926353e471955e8e684264e826da5b8643e83e
so just drop the override.

https://phabricator.endlessm.com/T33865
