### PR TITLE
Backport "safe-defaults: Start unit after eos-update-system-ca.service" to eos4.0

### DIFF
--- a/safe-defaults/eos-safe-defaults.service.in
+++ b/safe-defaults/eos-safe-defaults.service.in
@@ -2,7 +2,7 @@
 Description=Enable/update the Endless family-safe default settings
 DefaultDependencies=no
 Requires=local-fs.target
-After=local-fs.target
+After=local-fs.target eos-update-system-ca.service
 Before=NetworkManager.service systemd-update-done.service
 Conflicts=shutdown.target
 


### PR DESCRIPTION
Both of these units run `update-ca-certificates`, and that script makes no attempt to prevent concurrent execution.

https://phabricator.endlessm.com/T34308
(cherry picked from commit 2f0aa230d1f059fd3645aefe83b1efd2818684cf)