### PR TITLE
settings: Use new appstream CNAME

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -80,7 +80,7 @@ enabled=['org.learningequality.Kolibri.desktop']
 show-nonfree-ui=false
 enable-repos-dialog=false
 external-appstream-system-wide=true
-external-appstream-urls=['https://d3lapyynmdp1i9.cloudfront.net/app-info/eos-extra.xml.gz']
+external-appstream-urls=['https://appstream.endlessos.org/app-info/eos-extra.xml.gz']
 screenshot-cache-age-maximum=0
 
 # Remove default screencast duration limit


### PR DESCRIPTION
A nicer appstream.endlessos.org CNAME is being connected to the CloudFront CDN. Use that instead of the direct distribution domain name.

This depends on https://github.com/endlessm/eos-administration/pull/1303 being deployed.

https://phabricator.endlessm.com/T28855