### PR TITLE
gnome-software: Cleanup old eos-extra appstream downloads

### DIFF
--- a/gnome-software/Makefile.am
+++ b/gnome-software/Makefile.am
@@ -1,3 +1,7 @@
 # See doc/vendor-customisation.md in gnome-software.git
 backgrounddir = $(datadir)/gnome-software/backgrounds/
 dist_background_DATA = endless.png
+
+# Cleanup of legacy cache data.
+tmpfilesconfdir = $(prefix)/lib/tmpfiles.d
+dist_tmpfilesconf_DATA = gnome-software-cache.conf

--- a/gnome-software/gnome-software-cache.conf
+++ b/gnome-software/gnome-software-cache.conf
@@ -1,0 +1,5 @@
+# Cleanup old external eos-extra appstream downloads. This includes the
+# legacy appstream path as well as the newer appstream path derived from
+# the legacy d3lapyynmdp1i9.cloudfront.net URL.
+r /var/cache/app-info/xmls/org.gnome.Software-eos-extra.xml.gz
+r /var/cache/swcatalog/xml/org.gnome.Software-ce8395027bc2adcc3f5441bbf432cab1199cc889-eos-extra.xml.gz


### PR DESCRIPTION
At a minimum this will reclaim some disk space from unused files. Potentially it will remove conflicting entries if current eos-extra appstream catalog has different data than one of the legacy files.

https://phabricator.endlessm.com/T34337