### PR TITLE
tmpfiles packaging

### DIFF
--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -2,6 +2,7 @@ lib/systemd/system
 etc/containers/registries.conf.d
 etc/X11/Xsession.d
 usr/lib/NetworkManager/conf.d
+usr/lib/tmpfiles.d
 usr/sbin/eos-safe-defaults
 usr/share/dconf
 usr/share/eos-default-settings

--- a/debian/eos-icon-theme.dirs
+++ b/debian/eos-icon-theme.dirs
@@ -1,3 +1,0 @@
-etc/X11/Xsession.d
-etc/profile.d
-lib/tmpfiles.d


### PR DESCRIPTION
Actually install the `gnome-software-cache.conf` tmpfiles configuration.

https://phabricator.endlessm.com/T34337