### PR TITLE
GSchema: disable overlay scrollbars

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -6,6 +6,7 @@ icon-theme='EndlessOS'
 [org.gnome.desktop.interface]
 font-name='Lato 12'
 document-font-name='Lato 12'
+overlay-scrolling=false
 
 # This restores the default from gsettings-desktop-schemas that Debian
 # overrides because Source Code Pro isn't packaged.


### PR DESCRIPTION
I noticed there is an old override to disable overlay scrollbars, but this is just a GSetting now for GTK4 apps, at least.