### PR TITLE
Revert "Set default Nautilus view to list view"

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -39,10 +39,6 @@ picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 [org.gnome.shell]
 always-show-log-out=true
 
-# Set Nautilus default view to list view
-[org.gnome.nautilus.preferences]
-default-folder-viewer='list-view'
-
 # Decrease the likelihood that an unsteady click is interpreted as a drag
 [org.gnome.settings-daemon.peripherals.mouse]
 drag-threshold=10


### PR DESCRIPTION
This reverts commit c81b7d98fe1c3da35809a05d334bcf716ab384ab.

The [original request] was from over a decade ago, and we have effectively an entirely new Files experience since then, especially as we look to rebase on an even newer GNOME with the GTK4 port of Files.

Let's inherit the upstream defaults here; if we discover a usability issue from the field, we should bring that feedback upstream to GNOME since we're involved with the design team there.

[original request]: https://github.com/endlessm/eos-shell/issues/331