### PR TITLE
Revert "Decrease the likelihood that an unsteady click is interpreted as a drag"

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -39,10 +39,6 @@ picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 [org.gnome.shell]
 always-show-log-out=true
 
-# Decrease the likelihood that an unsteady click is interpreted as a drag
-[org.gnome.settings-daemon.peripherals.mouse]
-drag-threshold=10
-
 # Automatically import user's pictures into Shotwell
 [org.yorba.shotwell.preferences.files]
 auto-import=true


### PR DESCRIPTION
This reverts commit ffcedd7efff2ab7a14e62849532c8ab8421c2548.

Similar to #388, the [original request] was from over a decade ago and looks to be working around a very specific hardware issue combined with the design of EOS at the time. Hardware has improved, it's possible drag detection has improved, and the app grid is completely different these days as well.

This setting doesn't even exist here, either, so I believe it's been a no-op for at least EOS5. 😄 There's `org.gnome.desktop.peripherals.mouse drag-threshold` but I haven't dug in to ensure it's the same thing.

Let's just inherit the upstream defaults here; if we discover a usability issue from the field, we should bring that feedback upstream to GNOME since we're involved with the design team there.

[original request]: https://github.com/endlessm/eos-shell/issues/517