### PR TITLE
Install & migrate gnome-initial-setup vendor.conf file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdunitdir='$${prefix}/lib/systemd/system' \
 	$(NULL)
 
-SUBDIRS = gnome-software
+SUBDIRS = gnome-initial-setup gnome-software
 
 if BUILD_ICONTHEME
 SUBDIRS += icons

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,7 @@ AC_CONFIG_FILES([
 Makefile
 faces/Makefile
 fonts/Makefile
+gnome-initial-setup/Makefile
 gnome-software/Makefile
 icons/Makefile
 safe-defaults/Makefile

--- a/gnome-initial-setup/Makefile.am
+++ b/gnome-initial-setup/Makefile.am
@@ -1,3 +1,5 @@
 # See README.md in gnome-initial-setup.git
 vendorconfdir = $(datadir)/gnome-initial-setup/
 dist_vendorconf_DATA = vendor.conf
+
+dist_systemdunit_DATA = eos-migrate-gnome-initial-setup-vendor-conf.service

--- a/gnome-initial-setup/Makefile.am
+++ b/gnome-initial-setup/Makefile.am
@@ -1,0 +1,3 @@
+# See README.md in gnome-initial-setup.git
+vendorconfdir = $(datadir)/gnome-initial-setup/
+dist_vendorconf_DATA = vendor.conf

--- a/gnome-initial-setup/eos-migrate-gnome-initial-setup-vendor-conf.service
+++ b/gnome-initial-setup/eos-migrate-gnome-initial-setup-vendor-conf.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Migrate GNOME Initial Setup vendor configuration to /etc
+Before=gdm.service
+ConditionPathExists=/var/lib/eos-image-defaults/branding/gnome-initial-setup.conf
+ConditionPathExists=!/etc/gnome-initial-setup/vendor.conf
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=mv /var/lib/eos-image-defaults/branding/gnome-initial-setup.conf /etc/gnome-initial-setup/vendor.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/gnome-initial-setup/vendor.conf
+++ b/gnome-initial-setup/vendor.conf
@@ -1,0 +1,2 @@
+[Language]
+initial_languages=en_US.UTF-8;pt_BR.UTF-8;es_MX.UTF-8;id_ID.UTF-8;fr_FR.UTF-8;ar_AE.UTF-8;ru_RU.UTF_8;ro_RO.UTF-8


### PR DESCRIPTION
This file is moved from eos-image-builder. The copy there also
contained:

    [pages]
    run_welcome_tour=false

but this key has not been read by Initial Setup for many years.

Rather than shipping this default list of languages as a mutable
customisation in every image, we will now ship the defaults in the
immutable OS and only override it if necessary for a particular image.

----

Although unlikely, it is possible that Initial Setup will run after the
OS has been updated:

- Perhaps the computer goes online during Initial Setup, the automatic
  updater runs, and then the user restarts without completing Initial
  Setup.

- Perhaps eos-factory-reset is used to remove all users.

Unlikely, but it is easy enough to preserve any vendor overrides in this
case. We can remove this unit in the next checkpoint after the release
containing this change.

https://phabricator.endlessm.com/T35040
