### PR TITLE
settings: Show last typed char in GTK password entries

### DIFF
--- a/debian/eos-default-settings.install
+++ b/debian/eos-default-settings.install
@@ -8,4 +8,6 @@ usr/share/dconf
 usr/share/eos-default-settings
 usr/share/eos-safe-defaults
 usr/share/glib-2.0/schemas
+usr/share/gtk-3.0
+usr/share/gtk-4.0
 usr/share/polkit-1/rules.d

--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -131,4 +131,4 @@ install-data-hook:
 uninstall-hook:
 	@rm -f  $(DESTDIR)$(themedir)/icon-theme.cache
 
-CLEANFILES = index.theme.in index.theme
+CLEANFILES = index.theme

--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -28,17 +28,17 @@ settings_DATA = \
 	$(NULL)
 
 xsessiondir = $(sysconfdir)/X11/Xsession.d
-xsession_DATA = \
+dist_xsession_DATA = \
 	65gtk-overlay-scrolling \
 	$(NULL)
 
 containers_settingsdir = $(sysconfdir)/containers/registries.conf.d
-containers_settings_DATA = \
+dist_containers_settings_DATA = \
 	00-default-registries.conf \
 	$(NULL)
 
 cupspkhelperdir = $(datadir)/polkit-1/rules.d
-cupspkhelper_DATA = \
+dist_cupspkhelper_DATA = \
 	com.endlessm.Config.Printing.rules \
 	$(NULL)
 
@@ -51,9 +51,6 @@ EXTRA_DIST = \
 	dconf-defaults/settings \
 	com.endlessm.settings.gschema.override.in \
 	user.in \
-	$(xsession_DATA) \
-	$(containers_settings_DATA) \
-	$(cupspkhelper_DATA) \
 	$(NULL)
 
 CLEANFILES = \

--- a/settings/Makefile.am
+++ b/settings/Makefile.am
@@ -27,6 +27,16 @@ settings_DATA = \
 	50_eos-theme.gschema.override \
 	$(NULL)
 
+gtk3settingsdir = $(datadir)/gtk-3.0
+dist_gtk3settings_DATA = \
+	settings.ini \
+	$(NULL)
+
+gtk4settingsdir = $(datadir)/gtk-4.0
+dist_gtk4settings_DATA = \
+	settings.ini \
+	$(NULL)
+
 xsessiondir = $(sysconfdir)/X11/Xsession.d
 dist_xsession_DATA = \
 	65gtk-overlay-scrolling \

--- a/settings/settings.ini
+++ b/settings/settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-entry-password-hint-timeout=600


### PR DESCRIPTION
Previously, we manually enabled this setting in our fork of
gnome-initial-setup. This requires maintaining a downstream patch
forever and also means the setting is not used by other password entries
in the OS, such as in Settings.

Instead, set this globally for GTK 3 and GTK 4.

This PR also includes a build fix which I have been working around (but which was easy to fix once I tried).

https://phabricator.endlessm.com/T27358
