### PR TITLE
settings: Remove clock-show-weekday override

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -16,7 +16,6 @@ monospace-font-name='Source Code Pro 10'
 
 # Hide the weekday by default
 [org.gnome.desktop.interface]
-clock-show-weekday=false
 avatar-directories=['/usr/share/pixmaps/faces/EndlessOS/']
 
 [org.gnome.desktop.wm.preferences]


### PR DESCRIPTION
This is the same setting as upstream: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/blob/master/schemas/org.gnome.desktop.interface.gschema.xml.in?ref_type=heads#L232-238