### PR TITLE
Settings: remove always-show-log-out override

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -35,10 +35,6 @@ picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 [org.gnome.desktop.screensaver]
 picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
 
-# Always enable log out
-[org.gnome.shell]
-always-show-log-out=true
-
 # Automatically import user's pictures into Shotwell
 [org.yorba.shotwell.preferences.files]
 auto-import=true


### PR DESCRIPTION
I don't believe Shell will ever hide the Log Out button on Endless OS in practice; it is [shown when](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/9a3913d4a02b3eff2f6e9047d7ebb61637a051fe/js/misc/systemActions.js#L404):

- Log out is allowed (not disabled by lockdown), AND
- Log out should show in the current mode (not the greeter/lockscreen), AND
- The system is:
  - multi-user, or
  - multi-session, or
  - a system account, or
  - it's not a local account

I've opened https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7245 for clarification, but I don't see a compelling reason to diverge from upstream here.