### PR TITLE
settings: Override dark wallpaper

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -30,6 +30,7 @@ button-layout='appmenu:minimize,maximize,close'
 # Specify the default background image
 [org.gnome.desktop.background]
 picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
+picture-uri-dark='file:///usr/share/eos-media/desktop-background-C.jpg'
 
 # Specify the default lock screen image
 [org.gnome.desktop.screensaver]


### PR DESCRIPTION
Currently just setting it to the normal wallpaper, to avoid getting an adwaita-dark wallpaper on eos5.2.

https://phabricator.endlessm.com/T35128