### PR TITLE
gnome-initial-setup: Create directory when migrating vendor.conf

### DIFF
--- a/gnome-initial-setup/eos-migrate-gnome-initial-setup-vendor-conf.service
+++ b/gnome-initial-setup/eos-migrate-gnome-initial-setup-vendor-conf.service
@@ -7,6 +7,7 @@ ConditionPathExists=!/etc/gnome-initial-setup/vendor.conf
 [Service]
 Type=oneshot
 RemainAfterExit=true
+ExecStart=mkdir -p /etc/gnome-initial-setup
 ExecStart=mv /var/lib/eos-image-defaults/branding/gnome-initial-setup.conf /etc/gnome-initial-setup/vendor.conf
 
 [Install]


### PR DESCRIPTION
There is no reason why /etc/gnome-initial-setup would exist: the
defaults are shipped in /usr. Create the directory as needed to migrate
any existing overrides.

Fixes 9bc9888753d4e483ac5231fc62a824d8855d70fa

https://phabricator.endlessm.com/T35040
