### PR TITLE
Revert "settings: enable GB18030 Chinese encoding by default in gedit"

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -77,10 +77,6 @@ external-appstream-system-wide=true
 external-appstream-urls=['https://appstream.endlessos.org/app-info/eos-extra.xml.gz']
 screenshot-cache-age-maximum=0
 
-# Enable GB18030 encoding in gedit
-[org.gnome.gedit.preferences.encodings]
-candidate-encodings=['UTF-8', 'GB18030', 'ISO-8859-15', 'UTF-16']
-
 [org.gnome.settings-daemon.plugins.media-keys]
 logout=[]
 


### PR DESCRIPTION
This reverts commit 887b2d644a510a803363f0c01d0be0c79535bd82.

This was added to pass a certification process for use in China, but
this is no longer relevant and we are no longer installing GEdit by
default.

https://phabricator.endlessm.com/T13540
https://phabricator.endlessm.com/T32962
