### PR TITLE
settings: Add dark wallpaper

### DIFF
--- a/settings/com.endlessm.settings.gschema.override.in
+++ b/settings/com.endlessm.settings.gschema.override.in
@@ -30,7 +30,7 @@ button-layout='appmenu:minimize,maximize,close'
 # Specify the default background image
 [org.gnome.desktop.background]
 picture-uri='file:///usr/share/eos-media/desktop-background-C.jpg'
-picture-uri-dark='file:///usr/share/eos-media/desktop-background-C.jpg'
+picture-uri-dark='file:///usr/share/eos-media/desktop-background-dark-C.jpg'
 
 # Specify the default lock screen image
 [org.gnome.desktop.screensaver]


### PR DESCRIPTION
Requires https://github.com/endlessm/eos-media/pull/61; once that's merged, we will have a new `-dark` variant of the wallpaper that is used by GNOME Shell when the system prefers a dark style.

https://phabricator.endlessm.com/T35296