### PR TITLE
safe-defaults: Copy Chrome's managed policies into /etc as real files

### DIFF
--- a/safe-defaults/tmpfiles-enable.conf.in
+++ b/safe-defaults/tmpfiles-enable.conf.in
@@ -8,8 +8,10 @@
 # in this file will be ineffective.
 L @SYSCONFDIR@/NetworkManager/conf.d/nm-use-dnsmasq.conf - - - - @DATAROOTDIR@/eos-safe-defaults/nm-use-dnsmasq.conf
 L @SYSCONFDIR@/NetworkManager/dnsmasq.d/dnsmasq-opendns-family-shield.conf - - - - @DATAROOTDIR@/eos-safe-defaults/dnsmasq-opendns-family-shield.conf
-L @SYSCONFDIR@/opt/chrome/policies/managed/dns-over-https.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome/policies/managed/dns-over-https.json
-L @SYSCONFDIR@/opt/chrome/policies/managed/safe-search.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome/policies/managed/chrome-safe-search.json
+r @SYSCONFDIR@/opt/chrome/policies/managed/dns-over-https.json
+r @SYSCONFDIR@/opt/chrome/policies/managed/safe-search.json
+C @SYSCONFDIR@/opt/chrome/policies/managed/dns-over-https.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome/policies/managed/dns-over-https.json
+C @SYSCONFDIR@/opt/chrome/policies/managed/safe-search.json - - - - @DATAROOTDIR@/eos-safe-defaults/chrome/policies/managed/chrome-safe-search.json
 D /run/flatpak/extension/org.chromium.Chromium.Policy.safe-search 0755 - - -
 D /run/flatpak/extension/org.chromium.Chromium.Policy.safe-search/@FLATPAK_ARCH@ 0755 - - -
 L /run/flatpak/extension/org.chromium.Chromium.Policy.safe-search/@FLATPAK_ARCH@/1 - - - - @DATAROOTDIR@/eos-safe-defaults/chrome


### PR DESCRIPTION
If run eos-safe-defaults enable, Chrome's managed policies link to the configurations in /usr/share/eos-safe-defaults/chrome/policies/managed/. This mechanism makes eos-apps' Chrome apply the policies correctly. However, Flathub's Chrome does not apply the policies as expected. Its /app/bin/chrome [1] only gathers managed policies "files" from host's system configuration. So, the prepared "links" will be skipped.

This commit makes tmpfiles.d [2] delete the old one and copy prepared managed policies into system configuration to fulfill Flathub Chrome's requirement: type of file. Delete, then copy ensures the policies are maintained by OSTree deployment accross update & boot.

[1]: https://github.com/flathub/com.google.Chrome/blob/master/chrome.sh
[2]: https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html

https://phabricator.endlessm.com/T26944