### PR TITLE
safe-defaults: Use update-ca-trust to update CA certificates

### DIFF
--- a/safe-defaults/eos-safe-defaults.in
+++ b/safe-defaults/eos-safe-defaults.in
@@ -21,12 +21,12 @@
 case "$1" in
   "enable")
     systemd-tmpfiles --create --remove @DATAROOTDIR@/eos-safe-defaults/tmpfiles-enable.conf
-    update-ca-certificates
+    update-ca-trust
     echo "$0: Enabled family-safe default configuration."
     ;;
   "disable")
     systemd-tmpfiles --remove @DATAROOTDIR@/eos-safe-defaults/tmpfiles-disable.conf
-    update-ca-certificates
+    update-ca-trust
     echo "$0: Disabled family-safe default configuration."
     ;;
   *)


### PR DESCRIPTION
EOS 7 is based on GNOME OS, which uses update-ca-trust, instead of update-ca-certificates.

Part-of: https://github.com/endlessm/eos-build-meta/issues/174